### PR TITLE
Screen Reader Friendly Visualization

### DIFF
--- a/src/content/Root.tsx
+++ b/src/content/Root.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import { collectElements } from "./dom";
+import { collectElements, elementNickName } from "./dom";
 import { ElementMeta } from "./types";
 import { MetaList } from "./components/MetaList";
 import { injectRoot } from "./injectRoot";
 import { Announcements } from "./components/Announcements";
 import { SettingsContext } from "./components/SettingsProvider";
 import { useLiveRegion } from "./hooks/useLiveRegion";
+import { VisuallyHidden } from "./components/VisuallyHidden";
+import { useLang } from "../useLang";
 
 export const Root = ({ parent }: { parent: Element }) => {
   const [metaList, setMetaList] = React.useState<ElementMeta[]>([]);
@@ -97,16 +99,26 @@ export const Root = ({ parent }: { parent: Element }) => {
     return () => observer.disconnect();
   }, [updateInfo, parent]);
 
+  const { t } = useLang();
+
   return (
-    <>
+    <div ref={containerRef}>
+      <VisuallyHidden>
+        <h1>Accessibility Visualizer {elementNickName(parent)}</h1>
+      </VisuallyHidden>
+      <VisuallyHidden>
+        <h2>{t("content.elements")}</h2>
+      </VisuallyHidden>
       <MetaList
         list={metaList}
         settings={settings}
-        ref={containerRef}
         width={width}
         height={height}
       />
+      <VisuallyHidden>
+        <h2>{t("content.liveRegions")}</h2>
+      </VisuallyHidden>
       <Announcements contents={announcements} ref={announcementsRef} />
-    </>
+    </div>
   );
 };

--- a/src/content/components/MetaInfo.tsx
+++ b/src/content/components/MetaInfo.tsx
@@ -1,6 +1,7 @@
 import { Settings } from "../../types";
 import { Category, ElementTip } from "../types";
 import { Tip } from "./Tip";
+import { VisuallyHidden } from "./VisuallyHidden";
 
 const colors = (category: Category): { border: string } => {
   switch (category) {
@@ -42,6 +43,7 @@ export const MetaInfo = ({
   height,
   tips,
   categories,
+  nickName,
   settings,
   rootWidth,
   rootHeight,
@@ -51,6 +53,7 @@ export const MetaInfo = ({
   width: number;
   height: number;
   tips: ElementTip[];
+  nickName: string;
   categories: Category[];
   settings: Settings;
   rootWidth: number;
@@ -80,6 +83,9 @@ export const MetaInfo = ({
         height,
       }}
     >
+      <VisuallyHidden>
+        <h3>{nickName}</h3>
+      </VisuallyHidden>
       {categories
         .filter((category) => settings[category])
         .map((category, i) => (
@@ -91,9 +97,10 @@ export const MetaInfo = ({
               ...colors(category),
               boxShadow: "0 0 0 1px #fff, inset 0 0 0 1px #fff",
             }}
+            aria-hidden="true"
           />
         ))}
-      <div
+      <dl
         style={{
           position: "absolute",
           zIndex: 1,
@@ -118,12 +125,16 @@ export const MetaInfo = ({
           maxWidth: "max(160px, 100%)",
           width: "max-content",
           flexWrap: "wrap",
+          margin: 0,
+          padding: 0,
+          border: 0,
+          background: "none",
         }}
       >
         {tips.map((tip, i) => (
           <Tip key={i} tip={tip} />
         ))}
-      </div>
+      </dl>
     </div>
   );
 };

--- a/src/content/components/MetaList.tsx
+++ b/src/content/components/MetaList.tsx
@@ -38,12 +38,7 @@ const MetaListRenderer = (
           !meta.hidden && (
             <MetaInfo
               key={i}
-              x={meta.x}
-              y={meta.y}
-              width={meta.width}
-              height={meta.height}
-              tips={meta.tips}
-              categories={meta.categories}
+              {...meta}
               settings={settings}
               rootHeight={height}
               rootWidth={width}

--- a/src/content/components/Tip.tsx
+++ b/src/content/components/Tip.tsx
@@ -141,12 +141,30 @@ export const Tip = ({ tip }: { tip: ElementTip }) => {
         gap: "4px",
       }}
     >
-      <Icon type={tip.type} />
-      {tip.type === "level"
-        ? `${t("messages.headingLevel")}${tip.content}`
-        : tip.type === "warning" || tip.type === "error"
-          ? t(tip.content)
-          : tip.content}
+      <dt
+        style={{
+          margin: 0,
+          padding: 0,
+          border: 0,
+          background: "none",
+        }}
+      >
+        <Icon type={tip.type} />
+      </dt>
+      <dd
+        style={{
+          margin: 0,
+          padding: 0,
+          border: 0,
+          background: "none",
+        }}
+      >
+        {tip.type === "level"
+          ? `${t("messages.headingLevel")}${tip.content}`
+          : tip.type === "warning" || tip.type === "error"
+            ? t(tip.content)
+            : tip.content}
+      </dd>
     </div>
   );
 };

--- a/src/content/components/VisuallyHidden.tsx
+++ b/src/content/components/VisuallyHidden.tsx
@@ -1,0 +1,16 @@
+export const VisuallyHidden = ({ children }: { children: React.ReactNode }) => (
+  <div
+    style={{
+      position: "absolute",
+      width: 1,
+      height: 1,
+      margin: -1,
+      padding: 0,
+      clip: "rect(1px, 1px, 1px, 1px)",
+      overflow: "hidden",
+      whiteSpace: "nowrap",
+    }}
+  >
+    {children}
+  </div>
+);

--- a/src/content/dom/collectElements.ts
+++ b/src/content/dom/collectElements.ts
@@ -9,6 +9,7 @@ import { LinkSelectors, linkTips } from "./tips/linkTips";
 import { ButtonSelectors, buttonTips } from "./tips/buttonTips";
 import { FormSelectors, formTips } from "./tips/formTips";
 import { imageTips, isImage, ImageSelectors } from "./tips/imageTips";
+import { elementNickName } from "./elementNickName";
 
 const Selector = [
   ...(ImageSelectors || []),
@@ -62,7 +63,7 @@ export const collectElements = (
     rootHeight,
     rootWidth,
     elements: [...root.querySelectorAll(Selector)]
-      .map((el: Element) => {
+      .map((el: Element): ElementMeta | null => {
         if (excludes.some((exclude: Element) => exclude.contains(el)))
           return null;
         const images = imageTips(el);
@@ -92,6 +93,7 @@ export const collectElements = (
             ...ariaHidden,
             ...global,
           ],
+          nickName: elementNickName(el),
         };
       })
       .filter((el): el is ElementMeta => el !== null),

--- a/src/content/dom/elementNickName.test.ts
+++ b/src/content/dom/elementNickName.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+import { elementNickName } from "./elementNickName";
+
+describe("elementNickName()", () => {
+  test("document.body", () => {
+    const element = document.body;
+    document.body.textContent = "text";
+    expect(elementNickName(element)).toBe("body");
+  });
+
+  test("img", () => {
+    const element = document.createElement("img");
+    element.src = "src";
+    element.alt = "alt";
+    element.id = "id";
+    expect(elementNickName(element)).toBe("img alt");
+  });
+
+  test("img empty alt", () => {
+    const element = document.createElement("img");
+    element.src = "src";
+    element.alt = "";
+    expect(elementNickName(element)).toBe("img");
+  });
+
+  test("img empty alt and id", () => {
+    const element = document.createElement("img");
+    element.src = "src";
+    element.alt = "";
+    element.id = "id";
+    expect(elementNickName(element)).toBe("img#id");
+  });
+
+  test("element has id and long textContent", () => {
+    const element = document.createElement("div");
+    element.id = "id";
+    element.textContent = "a".repeat(40);
+    expect(elementNickName(element)).toBe(`div ${"a".repeat(30)}...`);
+  });
+
+  test("element has id and textContent", () => {
+    const element = document.createElement("div");
+    element.id = "id";
+    element.textContent = "text";
+    expect(elementNickName(element)).toBe("div text");
+  });
+
+  test("element has id and empty", () => {
+    const element = document.createElement("div");
+    element.id = "id";
+    expect(elementNickName(element)).toBe("div#id");
+  });
+
+  test("element has textContent", () => {
+    const element = document.createElement("div");
+    element.textContent = "text";
+    expect(elementNickName(element)).toBe("div text");
+  });
+
+  test("element has long textContent", () => {
+    const element = document.createElement("div");
+    element.textContent = "a".repeat(40);
+    expect(elementNickName(element)).toBe(`div ${"a".repeat(30)}...`);
+  });
+
+  test("element has no id and empty", () => {
+    const element = document.createElement("div");
+    expect(elementNickName(element)).toBe("div");
+  });
+});

--- a/src/content/dom/elementNickName.ts
+++ b/src/content/dom/elementNickName.ts
@@ -1,0 +1,32 @@
+import { computeAccessibleName } from "dom-accessibility-api";
+
+const TEXT_THRESHOULD = 30 as const;
+const SINGLE_ELEMENTS = ["html", "head", "body", "main"] as const;
+const NON_TEXT_ELEMENTS = [
+  "img",
+  "input",
+  "select",
+  "textarea",
+  "svg",
+] as const;
+export const elementNickName = (element: Element): string => {
+  const tagName = element.tagName.toLowerCase();
+  const idAttr = element.getAttribute("id");
+  if (SINGLE_ELEMENTS.includes(tagName as (typeof SINGLE_ELEMENTS)[number])) {
+    return tagName;
+  }
+  if (
+    NON_TEXT_ELEMENTS.includes(tagName as (typeof NON_TEXT_ELEMENTS)[number])
+  ) {
+    const name = computeAccessibleName(element);
+    return `${tagName}${name ? ` ${name}` : idAttr ? `#${idAttr}` : ""}`;
+  }
+
+  const textContent = element.textContent ? element.textContent.trim() : "";
+  const suffix = textContent
+    ? ` ${textContent.slice(0, TEXT_THRESHOULD)}${textContent.length > TEXT_THRESHOULD ? "..." : ""}`
+    : idAttr
+      ? `#${idAttr}`
+      : "";
+  return `${tagName}${suffix}`;
+};

--- a/src/content/dom/index.ts
+++ b/src/content/dom/index.ts
@@ -3,3 +3,4 @@ export * from "./getPositionBaseElement";
 export * from "./collectElements";
 export * from "./isFocusable";
 export * from "./isAriaHidden";
+export * from "./elementNickName";

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -2,6 +2,7 @@ export type ElementMeta = {
   tips: ElementTip[];
   hidden: boolean;
   categories: Category[];
+  nickName: string;
 } & ElementPosition;
 
 export type ElementPosition = {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -36,5 +36,9 @@
     "noControlForLabel": "No control for label",
     "noNameAttr": "No name attribute",
     "noRadioGroup": "No radiobutton group"
+  },
+  "content": {
+    "elements": "Elements",
+    "liveRegions": "Live Regions"
   }
 }

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -36,5 +36,9 @@
     "noControlForLabel": "フォームコントロールなしのラベル",
     "noNameAttr": "name属性なし",
     "noRadioGroup": "ラジオボタングループなし"
+  },
+  "content": {
+    "elements": "要素",
+    "liveRegions": "ライブリージョン"
   }
 }


### PR DESCRIPTION
fix #14 

Visually hiddenな見出しを追加し、チップを定義リスト（dl, dt, dd要素）にしてみた。
dl, dt, ddがスクリーンリーダーではあんまり使い勝手が良くない問題があるので、[dl/dt/ddのスクリーンリーダーの読み上げをなんとかする](https://zenn.dev/yusukehirao/articles/dl-dt-dd-wai-aria)のやり方を検討したり、別の表現方法を考えてもいいと思っている。
要素ごとの見出しに何を置くべきか精査したい（そもそも、これは見えているべきなんじゃないかという気もしてきている）

（個人的にはふつうのWebサイトでスクリーンリーダーが対応していないからとdl, dt, dd要素の使用を避けることにはあまり同意しない立場だが、今回はスクリーンリーダーのためのコードなので、できるだけのことはしたい）