### PR TITLE
:bug: avoid top-level await

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -2,20 +2,22 @@ import { loadEnabled } from "../enabled";
 import { injectRoot } from "./injectRoot";
 import { SettingsMessage } from "../settings";
 
-let injected = false;
-const enabled = await loadEnabled();
-if (enabled) {
-  injectRoot(window, window.document.body);
-  injected = true;
-}
-
-const listener = (message: SettingsMessage) => {
-  if (message.type !== "updateEnabled") return;
-  if (message.enabled && !injected) {
+(async () => {
+  let injected = false;
+  const enabled = await loadEnabled();
+  if (enabled) {
     injectRoot(window, window.document.body);
     injected = true;
-  } else {
-    injected = false;
   }
-};
-chrome.runtime.onMessage.addListener(listener);
+
+  const listener = (message: SettingsMessage) => {
+    if (message.type !== "updateEnabled") return;
+    if (message.enabled && !injected) {
+      injectRoot(window, window.document.body);
+      injected = true;
+    } else {
+      injected = false;
+    }
+  };
+  chrome.runtime.onMessage.addListener(listener);
+})();


### PR DESCRIPTION
On 3.2.1 release workflow, it is failed because of top-level await.
Still there is a question what browser version we should support, but for shipping bugfixes, avoid it.