### PR TITLE
:+1: use closed shadowDOM

### DIFF
--- a/src/content/components/ElementList.tsx
+++ b/src/content/components/ElementList.tsx
@@ -13,7 +13,7 @@ export const ElementList = ({
   height: number;
 }) => {
   return (
-    <root.div>
+    <root.div mode="closed">
       <Style />
       <div
         className="ElementList"


### PR DESCRIPTION
closed shadowDOMにすると、axe DevToolsのコントラスト比計算に影響すくなさそう。
ためしてほかに問題なさそうなら入れる