### PR TITLE
:+1: show multiple borders

### DIFF
--- a/src/content/components/ElementInfo.tsx
+++ b/src/content/components/ElementInfo.tsx
@@ -12,7 +12,17 @@ type VerticalPosition =
   | "outer-top"
   | "outer-bottom";
 export const ElementInfo = ({
-  meta: { x, y, absoluteX, absoluteY, width, height, ruleResults, category },
+  meta: {
+    x,
+    y,
+    absoluteX,
+    absoluteY,
+    width,
+    height,
+    ruleResults,
+    category,
+    rects,
+  },
   rootWidth,
   rootHeight,
 }: {
@@ -141,11 +151,27 @@ export const ElementInfo = ({
             interactiveMode && hovered ? 1 : settings.tipOpacityPercent / 100,
         }}
       >
-        {ruleResults.length > 0 && (
-          <div
-            className={`ElementInfo__border ElementInfo__border--${category}`}
-          />
-        )}
+        {ruleResults.length > 0 &&
+          (rects.length > 0 ? (
+            rects.map((rect, i) => (
+              <div
+                key={i}
+                className={`ElementInfo__border ElementInfo__border--${category}`}
+                style={{
+                  top: rect.relativeY,
+                  left: rect.relativeX,
+                  bottom: "auto",
+                  right: "auto",
+                  width: rect.width,
+                  height: rect.height,
+                }}
+              />
+            ))
+          ) : (
+            <div
+              className={`ElementInfo__border ElementInfo__border--${category}`}
+            />
+          ))}
         <div
           className={[
             "ElementInfo__tips",

--- a/src/content/dom/collectElements.ts
+++ b/src/content/dom/collectElements.ts
@@ -108,9 +108,16 @@ export const collectElements = (
         }
         const role = getKnownRole(el);
         const name = computeAccessibleName(el);
+        const rects = Array.from(el.getClientRects()).map((rect) => ({
+          relativeX: rect.x - elementPosition.x + visibleX,
+          relativeY: rect.y - elementPosition.y + visibleY,
+          width: rect.width,
+          height: rect.height,
+        }));
 
         return {
           ...elementPosition,
+          rects,
           name: name || "",
           category: getElementCategory(el, role),
           ruleResults: Rules.reduce((prev, rule) => {

--- a/src/content/dom/getElementPosition.ts
+++ b/src/content/dom/getElementPosition.ts
@@ -8,12 +8,15 @@ export const getElementPosition = (
   if (el.tagName.toLowerCase() === "area") {
     return getAreaElementPosition(el, w, offsetX, offsetY);
   }
+  const scrollX = w.scrollX;
+  const scrollY = w.scrollY;
+
   const rect = el.getBoundingClientRect();
   return {
-    x: rect.x + w.scrollX - offsetX,
-    y: rect.y + w.scrollY - offsetY,
-    absoluteX: rect.x + w.scrollX,
-    absoluteY: rect.y + w.scrollY,
+    x: rect.x + scrollX - offsetX,
+    y: rect.y + scrollY - offsetY,
+    absoluteX: rect.x + scrollX,
+    absoluteY: rect.y + scrollY,
     width: rect.width,
     height: rect.height,
   };
@@ -34,32 +37,34 @@ const getAreaElementPosition = (
   const rect = (img || el).getBoundingClientRect();
   const coords = el.getAttribute("coords")?.split(",").map(Number);
   const shape = el.getAttribute("shape");
+  const scrollX = w.scrollX;
+  const scrollY = w.scrollY;
 
   if (coords && (shape === "rect" || !shape) && coords.length >= 4) {
     return {
-      x: rect.x + coords[0] + w.scrollX - offsetX,
-      y: rect.y + coords[1] + w.scrollY - offsetY,
-      absoluteX: rect.x + coords[0] + w.scrollX,
-      absoluteY: rect.y + coords[1] + w.scrollY,
+      x: rect.x + coords[0] + scrollX - offsetX,
+      y: rect.y + coords[1] + scrollY - offsetY,
+      absoluteX: rect.x + coords[0] + scrollX,
+      absoluteY: rect.y + coords[1] + scrollY,
       width: coords[2] - coords[0],
       height: coords[3] - coords[1],
     };
   }
   if (coords && shape === "circle" && coords.length >= 3) {
     return {
-      x: rect.x + coords[0] - coords[2] + w.scrollX - offsetX,
-      y: rect.y + coords[1] - coords[2] + w.scrollY - offsetY,
-      absoluteX: rect.x + coords[0] - coords[2] + w.scrollX,
-      absoluteY: rect.y + coords[1] - coords[2] + w.scrollY,
+      x: rect.x + coords[0] - coords[2] + scrollX - offsetX,
+      y: rect.y + coords[1] - coords[2] + scrollY - offsetY,
+      absoluteX: rect.x + coords[0] - coords[2] + scrollX,
+      absoluteY: rect.y + coords[1] - coords[2] + scrollY,
       width: coords[2] * 2,
       height: coords[2] * 2,
     };
   }
   if (coords && shape === "poly" && coords.length >= 6) {
     const absoluteX =
-      rect.x + Math.min(...coords.filter((_, i) => i % 2 === 0)) + w.scrollX;
+      rect.x + Math.min(...coords.filter((_, i) => i % 2 === 0)) + scrollX;
     const absoluteY =
-      rect.y + Math.min(...coords.filter((_, i) => i % 2 === 1)) + w.scrollY;
+      rect.y + Math.min(...coords.filter((_, i) => i % 2 === 1)) + scrollY;
     return {
       x: absoluteX - offsetX,
       y: absoluteY - offsetY,
@@ -74,10 +79,10 @@ const getAreaElementPosition = (
     };
   }
   return {
-    x: rect.x + w.scrollX - offsetX,
-    y: rect.y + w.scrollY - offsetY,
-    absoluteX: rect.x + w.scrollX,
-    absoluteY: rect.y + w.scrollY,
+    x: rect.x + scrollX - offsetX,
+    y: rect.y + scrollY - offsetY,
+    absoluteX: rect.x + scrollX,
+    absoluteY: rect.y + scrollY,
     width: rect.width,
     height: rect.height,
   };

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -4,6 +4,12 @@ export type ElementMeta = {
   name: string;
   category: Category;
   ruleResults: RuleResult[];
+  rects: {
+    relativeX: number;
+    relativeY: number;
+    width: number;
+    height: number;
+  }[];
 } & ElementPosition;
 
 export type ElementPosition = {


### PR DESCRIPTION
Added `rect` to each ElementMeta, that is created from result of `getClientRects()`. Indicating element position with them instead of position that is created from `getBoundingClientRect()`.

If the inline element lays on multiple lines, former it appears as one big rectangle, now it do as small multiple rectangls.