### PR TITLE
add preset tabs

### DIFF
--- a/apps/browser_extension/entrypoints/content/hooks/useElementMeta.ts
+++ b/apps/browser_extension/entrypoints/content/hooks/useElementMeta.ts
@@ -2,7 +2,9 @@ import React from "react";
 import { collectElements } from "../dom";
 import { ElementMeta } from "../types";
 import { SettingsContext } from "../contexts/SettingsContext";
-import { Settings } from "../../../src/settings";
+import { CategorySettings } from "../../../src/settings";
+import { getCategorySettingsFromMode } from "../../../src/settings/presets";
+import { defaultCustomCategorySettings } from "../../../src/settings/constatns";
 
 type Layer = {
   element: Element;
@@ -14,7 +16,7 @@ type Layer = {
 const collectTopLayers = (
   el: Element,
   container: Element | null,
-  settings: Settings,
+  categorySettings: CategorySettings,
   srcdoc: boolean | undefined,
 ) => {
   const elements = [...el.querySelectorAll("dialog, [popover]")];
@@ -24,7 +26,7 @@ const collectTopLayers = (
       const { elements, rootHeight, rootWidth } = collectElements(
         element,
         [],
-        settings,
+        categorySettings,
         { srcdoc },
       );
       return {
@@ -40,7 +42,7 @@ const collectTopLayers = (
 
 const collectIFrames = (
   iframeElements: HTMLIFrameElement[],
-  settings: Settings,
+  categorySettings: CategorySettings,
 ): Layer[] =>
   iframeElements
     .map((iframe): Layer | null => {
@@ -53,7 +55,7 @@ const collectIFrames = (
           const { elements, rootHeight, rootWidth } = collectElements(
             d.body,
             [],
-            settings,
+            categorySettings,
             { srcdoc: iframe.hasAttribute("srcdoc") },
           );
           return {
@@ -98,24 +100,30 @@ export const useElementMeta = ({
         setTopLayers([]);
         return;
       }
+
+      const categorySettings = getCategorySettingsFromMode(
+        settings.elementTypeMode,
+        defaultCustomCategorySettings,
+      );
+
       const display = containerRef.current.style.display;
       containerRef.current.style.display = "none";
 
       const topLayers = collectTopLayers(
         parentRef.current,
         containerRef.current,
-        settings,
+        categorySettings,
         srcdoc,
       );
       setTopLayers(topLayers);
-      setIframeLayers(collectIFrames(iframeElements, settings));
+      setIframeLayers(collectIFrames(iframeElements, categorySettings));
 
       const { elements, rootHeight, rootWidth } = collectElements(
         parentRef.current,
         [containerRef.current, ...topLayers.map((e) => e.element)].filter(
           (el): el is Element => !!el,
         ),
-        settings,
+        categorySettings,
         { srcdoc },
       );
       setMetaList(elements);

--- a/apps/browser_extension/entrypoints/options/OptionsPage.tsx
+++ b/apps/browser_extension/entrypoints/options/OptionsPage.tsx
@@ -41,6 +41,7 @@ export const OptionsPage = () => {
         settings={settings}
         onChange={updateSettings}
         showDisplaySettingsCollapsed={false}
+        useTabsForElementTypes={false}
       />
       <p className="text-sm text-gray-500">{t("optionsPage.description")}</p>
       <details ref={resetRef}>

--- a/apps/browser_extension/entrypoints/popup/Popup.tsx
+++ b/apps/browser_extension/entrypoints/popup/Popup.tsx
@@ -182,6 +182,7 @@ export const Popup = () => {
             onChange={updateSettings}
             disabled={!enabled}
             showDisplaySettingsCollapsed={true}
+            url={url}
           />
           <p className="text-xs text-zinc-500 dark:text-zinc-400 px-2">
             {t("popup.hostDesc")}

--- a/apps/browser_extension/src/components/ElementTypeTabs.tsx
+++ b/apps/browser_extension/src/components/ElementTypeTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useId, useCallback, KeyboardEvent } from "react";
+import React, { useRef, useId, useCallback, KeyboardEvent, useState, useEffect } from "react";
 import { CategorySettings, ElementTypeMode, PresetId } from "../settings/types";
 import { presets, getCategorySettingsFromMode } from "../settings/presets";
 import { defaultCustomCategorySettings } from "../settings/constatns";
@@ -40,6 +40,20 @@ export const ElementTypeTabs: React.FC<ElementTypeTabsProps> = ({
   const tabPanelId = useId();
   const tabListId = useId();
 
+  // カスタム設定を独立して保持するstate
+  const [customSettings, setCustomSettings] = useState<CategorySettings>(() => {
+    return elementTypeMode.mode === "custom" 
+      ? elementTypeMode.settings 
+      : defaultCustomCategorySettings;
+  });
+
+  // elementTypeModeが変更されたときにcustomSettingsを更新
+  useEffect(() => {
+    if (elementTypeMode.mode === "custom") {
+      setCustomSettings(elementTypeMode.settings);
+    }
+  }, [elementTypeMode]);
+
   const currentCategorySettings = getCategorySettingsFromMode(
     elementTypeMode,
     defaultCustomCategorySettings,
@@ -50,10 +64,10 @@ export const ElementTypeTabs: React.FC<ElementTypeTabsProps> = ({
   const handlePresetChange = useCallback(
     (presetId: PresetId) => {
       if (presetId === "custom") {
-        // カスタムモードに切り替え（現在の設定を保持）
+        // カスタムモードに切り替え（保持しているカスタム設定を使用）
         onChange({
           mode: "custom",
-          settings: currentCategorySettings,
+          settings: customSettings,
         });
       } else {
         // プリセットモードに切り替え
@@ -63,15 +77,19 @@ export const ElementTypeTabs: React.FC<ElementTypeTabsProps> = ({
         });
       }
     },
-    [currentCategorySettings, onChange],
+    [customSettings, onChange],
   );
 
   const handleCheckboxChange = useCallback(
     (key: keyof CategorySettings, checked: boolean) => {
+      // 新しいカスタム設定を作成
       const newCustomSettings = {
-        ...currentCategorySettings,
+        ...customSettings,
         [key]: checked,
       };
+
+      // カスタム設定を更新
+      setCustomSettings(newCustomSettings);
 
       // チェックボックス変更は常にカスタムモード
       onChange({
@@ -79,7 +97,7 @@ export const ElementTypeTabs: React.FC<ElementTypeTabsProps> = ({
         settings: newCustomSettings,
       });
     },
-    [currentCategorySettings, onChange],
+    [customSettings, onChange],
   );
 
   const handleTabKeyDown = useCallback(
@@ -165,9 +183,9 @@ export const ElementTypeTabs: React.FC<ElementTypeTabsProps> = ({
               aria-selected={activeTab === preset.id}
               aria-controls={`${tabPanelId}-panel`}
               tabIndex={activeTab === preset.id ? 0 : -1}
-              className={`px-3 py-2 text-xs font-medium whitespace-nowrap transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-inset border-b-2 ${
+              className={`px-3 py-2 text-xs font-medium whitespace-nowrap transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-inset border-b-2 ${
                 activeTab === preset.id
-                  ? "border-teal-500 text-teal-700 bg-white dark:text-teal-400 dark:bg-zinc-800"
+                  ? "border-teal-500 text-teal-700 dark:text-teal-400"
                   : "border-transparent text-zinc-600 hover:enabled:text-zinc-800 hover:enabled:border-zinc-300 dark:text-zinc-400 dark:hover:enabled:text-zinc-200 dark:hover:enabled:border-zinc-500"
               } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
               onClick={() => handlePresetChange(preset.id)}
@@ -185,9 +203,9 @@ export const ElementTypeTabs: React.FC<ElementTypeTabsProps> = ({
             aria-selected={activeTab === "custom"}
             aria-controls={`${tabPanelId}-panel`}
             tabIndex={activeTab === "custom" ? 0 : -1}
-            className={`px-3 py-2 text-xs font-medium whitespace-nowrap transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-inset border-b-2 ${
+            className={`px-3 py-2 text-xs font-medium whitespace-nowrap transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-inset border-b-2 ${
               activeTab === "custom"
-                ? "border-teal-500 text-teal-700 bg-white dark:text-teal-400 dark:bg-zinc-800"
+                ? "border-teal-500 text-teal-700 dark:text-teal-400"
                 : "border-transparent text-zinc-600 hover:enabled:text-zinc-800 hover:enabled:border-zinc-300 dark:text-zinc-400 dark:hover:enabled:text-zinc-200 dark:hover:enabled:border-zinc-500"
             } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
             onClick={() => handlePresetChange("custom")}
@@ -307,7 +325,7 @@ export const ElementTypeTabs: React.FC<ElementTypeTabsProps> = ({
                   (label) => (
                     <span
                       key={label}
-                      className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200"
+                      className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-teal-200 text-teal-800 dark:bg-teal-900 dark:text-teal-200 border dark:border-0 border-teal-400"
                     >
                       {label}
                     </span>

--- a/apps/browser_extension/src/components/ElementTypeTabs.tsx
+++ b/apps/browser_extension/src/components/ElementTypeTabs.tsx
@@ -359,7 +359,7 @@ export const ElementTypeTabs: React.FC<ElementTypeTabsProps> = ({
                   (label) => (
                     <span
                       key={label}
-                      className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-teal-200 text-teal-800 dark:bg-teal-900 dark:text-teal-200 border dark:border-0 border-teal-400"
+                      className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-teal-50 text-teal-800 dark:bg-teal-900 dark:text-teal-200 border dark:border-0 border-teal-400"
                     >
                       {label}
                     </span>

--- a/apps/browser_extension/src/components/ElementTypeTabs.tsx
+++ b/apps/browser_extension/src/components/ElementTypeTabs.tsx
@@ -1,0 +1,323 @@
+import React, { useRef, useId, useCallback, KeyboardEvent } from "react";
+import { CategorySettings, ElementTypeMode, PresetId } from "../settings/types";
+import { presets, getCategorySettingsFromMode } from "../settings/presets";
+import { defaultCustomCategorySettings } from "../settings/constatns";
+import { useLang } from "../useLang";
+import { Checkbox } from "./Checkbox";
+
+const getEnabledSettingsLabels = (
+  settings: CategorySettings,
+  t: (key: string) => string,
+): string[] => {
+  const labels: string[] = [];
+  if (settings.heading) labels.push(t("settings.headings"));
+  if (settings.image) labels.push(t("settings.images"));
+  if (settings.ariaHidden) labels.push(t("settings.ariaHidden"));
+  if (settings.formControl) labels.push(t("settings.formControls"));
+  if (settings.button) labels.push(t("settings.buttons"));
+  if (settings.link) labels.push(t("settings.links"));
+  if (settings.section) labels.push(t("settings.sections"));
+  if (settings.page) labels.push(t("settings.page"));
+  if (settings.lang) labels.push(t("settings.lang"));
+  if (settings.table) labels.push(t("settings.tables"));
+  if (settings.list) labels.push(t("settings.lists"));
+  return labels;
+};
+
+interface ElementTypeTabsProps {
+  elementTypeMode: ElementTypeMode;
+  onChange: (elementTypeMode: ElementTypeMode) => void;
+  disabled?: boolean;
+}
+
+export const ElementTypeTabs: React.FC<ElementTypeTabsProps> = ({
+  elementTypeMode,
+  onChange,
+  disabled = false,
+}) => {
+  const { t } = useLang();
+  const tabListRef = useRef<HTMLDivElement>(null);
+  const tabPanelId = useId();
+  const tabListId = useId();
+
+  const currentCategorySettings = getCategorySettingsFromMode(
+    elementTypeMode,
+    defaultCustomCategorySettings,
+  );
+  const activeTab: PresetId =
+    elementTypeMode.mode === "preset" ? elementTypeMode.presetId : "custom";
+
+  const handlePresetChange = useCallback(
+    (presetId: PresetId) => {
+      if (presetId === "custom") {
+        // カスタムモードに切り替え（現在の設定を保持）
+        onChange({
+          mode: "custom",
+          settings: currentCategorySettings,
+        });
+      } else {
+        // プリセットモードに切り替え
+        onChange({
+          mode: "preset",
+          presetId: presetId,
+        });
+      }
+    },
+    [currentCategorySettings, onChange],
+  );
+
+  const handleCheckboxChange = useCallback(
+    (key: keyof CategorySettings, checked: boolean) => {
+      const newCustomSettings = {
+        ...currentCategorySettings,
+        [key]: checked,
+      };
+
+      // チェックボックス変更は常にカスタムモード
+      onChange({
+        mode: "custom",
+        settings: newCustomSettings,
+      });
+    },
+    [currentCategorySettings, onChange],
+  );
+
+  const handleTabKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (disabled) return;
+
+      const currentTarget = event.currentTarget;
+      const tabList = tabListRef.current;
+      if (!tabList) return;
+
+      const tabs = Array.from(
+        tabList.querySelectorAll('[role="tab"]'),
+      ) as HTMLButtonElement[];
+      const currentIndex = tabs.indexOf(currentTarget);
+
+      // すべてのタブ（プリセット + カスタム）のIDリスト
+      const allTabIds: PresetId[] = [...presets.map((p) => p.id), "custom"];
+
+      switch (event.key) {
+        case "ArrowLeft":
+        case "ArrowUp": {
+          event.preventDefault();
+          const prevIndex =
+            currentIndex === 0 ? tabs.length - 1 : currentIndex - 1;
+          tabs[prevIndex]?.focus();
+          const prevTabId = allTabIds[prevIndex];
+          if (prevTabId) {
+            handlePresetChange(prevTabId);
+          }
+          break;
+        }
+        case "ArrowRight":
+        case "ArrowDown": {
+          event.preventDefault();
+          const nextIndex =
+            currentIndex === tabs.length - 1 ? 0 : currentIndex + 1;
+          tabs[nextIndex]?.focus();
+          const nextTabId = allTabIds[nextIndex];
+          if (nextTabId) {
+            handlePresetChange(nextTabId);
+          }
+          break;
+        }
+        case "Home":
+          event.preventDefault();
+          tabs[0]?.focus();
+          handlePresetChange(allTabIds[0]);
+          break;
+        case "End":
+          event.preventDefault();
+          tabs[tabs.length - 1]?.focus();
+          handlePresetChange(allTabIds[allTabIds.length - 1]);
+          break;
+      }
+    },
+    [disabled, handlePresetChange],
+  );
+
+  return (
+    <div className="px-2 py-1 bg-zinc-100 dark:bg-zinc-800 rounded-md">
+      <fieldset className="border-0 flex flex-col">
+        <legend
+          className={`text-xs ${disabled ? "text-zinc-700 dark:text-zinc-300" : "text-teal-800 dark:text-teal-200"} font-bold mb-1`}
+          id={tabListId}
+        >
+          {t("settings.elementTypes")}
+        </legend>
+
+        {/* タブリスト */}
+        <div
+          ref={tabListRef}
+          role="tablist"
+          aria-labelledby={tabListId}
+          aria-orientation="horizontal"
+          className="flex flex-row mb-2 overflow-x-auto border-b border-zinc-300 dark:border-zinc-600 px-1 -mx-1"
+        >
+          {presets.map((preset) => (
+            <button
+              key={preset.id}
+              type="button"
+              role="tab"
+              id={`tab-${preset.id}`}
+              aria-selected={activeTab === preset.id}
+              aria-controls={`${tabPanelId}-panel`}
+              tabIndex={activeTab === preset.id ? 0 : -1}
+              className={`px-3 py-2 text-xs font-medium whitespace-nowrap transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-inset border-b-2 ${
+                activeTab === preset.id
+                  ? "border-teal-500 text-teal-700 bg-white dark:text-teal-400 dark:bg-zinc-800"
+                  : "border-transparent text-zinc-600 hover:enabled:text-zinc-800 hover:enabled:border-zinc-300 dark:text-zinc-400 dark:hover:enabled:text-zinc-200 dark:hover:enabled:border-zinc-500"
+              } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
+              onClick={() => handlePresetChange(preset.id)}
+              onKeyDown={handleTabKeyDown}
+              disabled={disabled}
+            >
+              {t(preset.labelKey)}
+            </button>
+          ))}
+          <button
+            key="custom"
+            type="button"
+            role="tab"
+            id="tab-custom"
+            aria-selected={activeTab === "custom"}
+            aria-controls={`${tabPanelId}-panel`}
+            tabIndex={activeTab === "custom" ? 0 : -1}
+            className={`px-3 py-2 text-xs font-medium whitespace-nowrap transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-inset border-b-2 ${
+              activeTab === "custom"
+                ? "border-teal-500 text-teal-700 bg-white dark:text-teal-400 dark:bg-zinc-800"
+                : "border-transparent text-zinc-600 hover:enabled:text-zinc-800 hover:enabled:border-zinc-300 dark:text-zinc-400 dark:hover:enabled:text-zinc-200 dark:hover:enabled:border-zinc-500"
+            } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
+            onClick={() => handlePresetChange("custom")}
+            onKeyDown={handleTabKeyDown}
+            disabled={disabled}
+          >
+            {t("presets.custom")}
+          </button>
+        </div>
+
+        {/* タブパネル */}
+        <div
+          role="tabpanel"
+          id={`${tabPanelId}-panel`}
+          aria-labelledby={`tab-${activeTab}`}
+          tabIndex={0}
+        >
+          {/* カスタムタブの場合のみチェックボックスを表示 */}
+          {activeTab === "custom" ? (
+            <div className="flex flex-row flex-wrap gap-x-3 gap-y-1 items-center">
+              <Checkbox
+                onChange={(e) =>
+                  handleCheckboxChange("heading", e.target.checked)
+                }
+                checked={currentCategorySettings.heading}
+                disabled={disabled}
+              >
+                <span className="text-sm">{t("settings.headings")}</span>
+              </Checkbox>
+              <Checkbox
+                onChange={(e) =>
+                  handleCheckboxChange("image", e.target.checked)
+                }
+                checked={currentCategorySettings.image}
+                disabled={disabled}
+              >
+                <span className="text-sm">{t("settings.images")}</span>
+              </Checkbox>
+              <Checkbox
+                onChange={(e) =>
+                  handleCheckboxChange("ariaHidden", e.target.checked)
+                }
+                checked={currentCategorySettings.ariaHidden}
+                disabled={disabled}
+              >
+                <span className="text-sm">{t("settings.ariaHidden")}</span>
+              </Checkbox>
+              <Checkbox
+                onChange={(e) =>
+                  handleCheckboxChange("formControl", e.target.checked)
+                }
+                checked={currentCategorySettings.formControl}
+                disabled={disabled}
+              >
+                <span className="text-sm">{t("settings.formControls")}</span>
+              </Checkbox>
+              <Checkbox
+                onChange={(e) =>
+                  handleCheckboxChange("button", e.target.checked)
+                }
+                checked={currentCategorySettings.button}
+                disabled={disabled}
+              >
+                <span className="text-sm">{t("settings.buttons")}</span>
+              </Checkbox>
+              <Checkbox
+                onChange={(e) => handleCheckboxChange("link", e.target.checked)}
+                checked={currentCategorySettings.link}
+                disabled={disabled}
+              >
+                <span className="text-sm">{t("settings.links")}</span>
+              </Checkbox>
+              <Checkbox
+                onChange={(e) =>
+                  handleCheckboxChange("section", e.target.checked)
+                }
+                checked={currentCategorySettings.section}
+                disabled={disabled}
+              >
+                <span className="text-sm">{t("settings.sections")}</span>
+              </Checkbox>
+              <Checkbox
+                onChange={(e) => handleCheckboxChange("page", e.target.checked)}
+                checked={currentCategorySettings.page}
+                disabled={disabled}
+              >
+                <span className="text-sm">{t("settings.page")}</span>
+              </Checkbox>
+              <Checkbox
+                onChange={(e) => handleCheckboxChange("lang", e.target.checked)}
+                checked={currentCategorySettings.lang}
+                disabled={disabled}
+              >
+                <span className="text-sm">{t("settings.lang")}</span>
+              </Checkbox>
+              <Checkbox
+                onChange={(e) =>
+                  handleCheckboxChange("table", e.target.checked)
+                }
+                checked={currentCategorySettings.table}
+                disabled={disabled}
+              >
+                <span className="text-sm">{t("settings.tables")}</span>
+              </Checkbox>
+              <Checkbox
+                onChange={(e) => handleCheckboxChange("list", e.target.checked)}
+                checked={currentCategorySettings.list}
+                disabled={disabled}
+              >
+                <span className="text-sm">{t("settings.lists")}</span>
+              </Checkbox>
+            </div>
+          ) : (
+            <div className="px-2 py-1">
+              <div className="flex flex-row flex-wrap gap-x-2 gap-y-1 items-center">
+                {getEnabledSettingsLabels(currentCategorySettings, t).map(
+                  (label) => (
+                    <span
+                      key={label}
+                      className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200"
+                    >
+                      {label}
+                    </span>
+                  ),
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </fieldset>
+    </div>
+  );
+};

--- a/apps/browser_extension/src/components/SettingsEditor.tsx
+++ b/apps/browser_extension/src/components/SettingsEditor.tsx
@@ -12,12 +12,14 @@ export const SettingsEditor = ({
   disabled,
   showDisplaySettingsCollapsed = false,
   useTabsForElementTypes = true,
+  url,
 }: {
   settings: Settings;
   onChange: (settings: Settings) => void;
   disabled?: boolean;
   showDisplaySettingsCollapsed?: boolean;
   useTabsForElementTypes?: boolean;
+  url?: string;
 }) => {
   const { t, lang } = useLang();
   const handleChangeCheckbox = (
@@ -109,6 +111,7 @@ export const SettingsEditor = ({
                 elementTypeMode={settings.elementTypeMode}
                 onChange={handleElementTypeModeChange}
                 disabled={disabled || !settings.accessibilityInfo}
+                url={url}
               />
             ) : (
               <div className="px-2 py-1 bg-zinc-100 dark:bg-zinc-800 rounded-md">

--- a/apps/browser_extension/src/components/SettingsEditor.tsx
+++ b/apps/browser_extension/src/components/SettingsEditor.tsx
@@ -1,18 +1,23 @@
 import { ChangeEvent, useState } from "react";
-import { Settings } from "../settings/types";
+import { Settings, ElementTypeMode, CategorySettings } from "../settings/types";
 import { useLang } from "../useLang";
 import { Checkbox } from "./Checkbox";
+import { ElementTypeTabs } from "./ElementTypeTabs";
+import { getCategorySettingsFromMode } from "../settings/presets";
+import { defaultCustomCategorySettings } from "../settings/constatns";
 
 export const SettingsEditor = ({
   settings,
   onChange,
   disabled,
   showDisplaySettingsCollapsed = false,
+  useTabsForElementTypes = true,
 }: {
   settings: Settings;
   onChange: (settings: Settings) => void;
   disabled?: boolean;
   showDisplaySettingsCollapsed?: boolean;
+  useTabsForElementTypes?: boolean;
 }) => {
   const { t, lang } = useLang();
   const handleChangeCheckbox = (
@@ -34,6 +39,40 @@ export const SettingsEditor = ({
       [key]: parseFloat(e.target.value),
     };
     onChange(newSettings);
+  };
+
+  const handleElementTypeModeChange = (elementTypeMode: ElementTypeMode) => {
+    const newSettings = {
+      ...settings,
+      elementTypeMode,
+    };
+    onChange(newSettings);
+  };
+
+  const handleCategorySettingsChange = (categorySettings: CategorySettings) => {
+    const newSettings = {
+      ...settings,
+      elementTypeMode: {
+        mode: "custom" as const,
+        settings: categorySettings,
+      },
+    };
+    onChange(newSettings);
+  };
+
+  const handleCategoryCheckboxChange = (
+    key: keyof CategorySettings,
+    checked: boolean,
+  ) => {
+    const currentCategorySettings = getCategorySettingsFromMode(
+      settings.elementTypeMode,
+      defaultCustomCategorySettings,
+    );
+    const newCategorySettings = {
+      ...currentCategorySettings,
+      [key]: checked,
+    };
+    handleCategorySettingsChange(newCategorySettings);
   };
 
   return (
@@ -65,118 +104,195 @@ export const SettingsEditor = ({
             </Checkbox>
           </div>
           <div className="flex flex-col gap-2">
-            <div className="px-2 py-1 bg-zinc-100 dark:bg-zinc-800 rounded-md">
-              <fieldset className="border-0 flex flex-col">
-                <legend
-                  className={`text-xs ${disabled || !settings.accessibilityInfo ? "text-zinc-700 dark:text-zinc-300" : "text-teal-800 dark:text-teal-200"} font-bold mb-1`}
-                >
-                  {t("settings.elementTypes")}
-                </legend>
-                <div className="flex flex-row flex-wrap gap-x-3 gap-y-1 items-center">
-                  <Checkbox
-                    onChange={(e) => {
-                      handleChangeCheckbox("heading", e);
-                    }}
-                    checked={settings.heading}
-                    disabled={disabled || !settings.accessibilityInfo}
+            {useTabsForElementTypes ? (
+              <ElementTypeTabs
+                elementTypeMode={settings.elementTypeMode}
+                onChange={handleElementTypeModeChange}
+                disabled={disabled || !settings.accessibilityInfo}
+              />
+            ) : (
+              <div className="px-2 py-1 bg-zinc-100 dark:bg-zinc-800 rounded-md">
+                <fieldset className="border-0 flex flex-col">
+                  <legend
+                    className={`text-xs ${disabled || !settings.accessibilityInfo ? "text-zinc-700 dark:text-zinc-300" : "text-teal-800 dark:text-teal-200"} font-bold mb-1`}
                   >
-                    <span className="text-sm">{t("settings.headings")}</span>
-                  </Checkbox>
-                  <Checkbox
-                    onChange={(e) => {
-                      handleChangeCheckbox("image", e);
-                    }}
-                    checked={settings.image}
-                    disabled={disabled || !settings.accessibilityInfo}
-                  >
-                    <span className="text-sm">{t("settings.images")}</span>
-                  </Checkbox>
-                  <Checkbox
-                    onChange={(e) => {
-                      handleChangeCheckbox("ariaHidden", e);
-                    }}
-                    checked={settings.ariaHidden}
-                    disabled={disabled || !settings.accessibilityInfo}
-                  >
-                    <span className="text-sm">{t("settings.ariaHidden")}</span>
-                  </Checkbox>
-                  <Checkbox
-                    onChange={(e) => {
-                      handleChangeCheckbox("formControl", e);
-                    }}
-                    checked={settings.formControl}
-                    disabled={disabled || !settings.accessibilityInfo}
-                  >
-                    <span className="text-sm">
-                      {t("settings.formControls")}
-                    </span>
-                  </Checkbox>
-                  <Checkbox
-                    onChange={(e) => {
-                      handleChangeCheckbox("button", e);
-                    }}
-                    checked={settings.button}
-                    disabled={disabled || !settings.accessibilityInfo}
-                  >
-                    <span className="text-sm">{t("settings.buttons")}</span>
-                  </Checkbox>
-                  <Checkbox
-                    onChange={(e) => {
-                      handleChangeCheckbox("link", e);
-                    }}
-                    checked={settings.link}
-                    disabled={disabled || !settings.accessibilityInfo}
-                  >
-                    <span className="text-sm">{t("settings.links")}</span>
-                  </Checkbox>
-                  <Checkbox
-                    onChange={(e) => {
-                      handleChangeCheckbox("section", e);
-                    }}
-                    checked={settings.section}
-                    disabled={disabled || !settings.accessibilityInfo}
-                  >
-                    <span className="text-sm">{t("settings.sections")}</span>
-                  </Checkbox>
-                  <Checkbox
-                    onChange={(e) => {
-                      handleChangeCheckbox("page", e);
-                    }}
-                    checked={settings.page}
-                    disabled={disabled || !settings.accessibilityInfo}
-                  >
-                    <span className="text-sm">{t("settings.page")}</span>
-                  </Checkbox>
-                  <Checkbox
-                    onChange={(e) => {
-                      handleChangeCheckbox("lang", e);
-                    }}
-                    checked={settings.lang}
-                    disabled={disabled || !settings.accessibilityInfo}
-                  >
-                    <span className="text-sm">{t("settings.lang")}</span>
-                  </Checkbox>
-                  <Checkbox
-                    onChange={(e) => {
-                      handleChangeCheckbox("table", e);
-                    }}
-                    checked={settings.table}
-                    disabled={disabled || !settings.accessibilityInfo}
-                  >
-                    <span className="text-sm">{t("settings.tables")}</span>
-                  </Checkbox>
-                  <Checkbox
-                    onChange={(e) => {
-                      handleChangeCheckbox("list", e);
-                    }}
-                    checked={settings.list}
-                    disabled={disabled || !settings.accessibilityInfo}
-                  >
-                    <span className="text-sm">{t("settings.lists")}</span>
-                  </Checkbox>
-                </div>
-              </fieldset>
-            </div>
+                    {t("settings.elementTypes")}
+                  </legend>
+                  <div className="flex flex-row flex-wrap gap-x-3 gap-y-1 items-center">
+                    <Checkbox
+                      onChange={(e) =>
+                        handleCategoryCheckboxChange(
+                          "heading",
+                          e.target.checked,
+                        )
+                      }
+                      checked={
+                        getCategorySettingsFromMode(
+                          settings.elementTypeMode,
+                          defaultCustomCategorySettings,
+                        ).heading
+                      }
+                      disabled={disabled || !settings.accessibilityInfo}
+                    >
+                      <span className="text-sm">{t("settings.headings")}</span>
+                    </Checkbox>
+                    <Checkbox
+                      onChange={(e) =>
+                        handleCategoryCheckboxChange("image", e.target.checked)
+                      }
+                      checked={
+                        getCategorySettingsFromMode(
+                          settings.elementTypeMode,
+                          defaultCustomCategorySettings,
+                        ).image
+                      }
+                      disabled={disabled || !settings.accessibilityInfo}
+                    >
+                      <span className="text-sm">{t("settings.images")}</span>
+                    </Checkbox>
+                    <Checkbox
+                      onChange={(e) =>
+                        handleCategoryCheckboxChange(
+                          "ariaHidden",
+                          e.target.checked,
+                        )
+                      }
+                      checked={
+                        getCategorySettingsFromMode(
+                          settings.elementTypeMode,
+                          defaultCustomCategorySettings,
+                        ).ariaHidden
+                      }
+                      disabled={disabled || !settings.accessibilityInfo}
+                    >
+                      <span className="text-sm">
+                        {t("settings.ariaHidden")}
+                      </span>
+                    </Checkbox>
+                    <Checkbox
+                      onChange={(e) =>
+                        handleCategoryCheckboxChange(
+                          "formControl",
+                          e.target.checked,
+                        )
+                      }
+                      checked={
+                        getCategorySettingsFromMode(
+                          settings.elementTypeMode,
+                          defaultCustomCategorySettings,
+                        ).formControl
+                      }
+                      disabled={disabled || !settings.accessibilityInfo}
+                    >
+                      <span className="text-sm">
+                        {t("settings.formControls")}
+                      </span>
+                    </Checkbox>
+                    <Checkbox
+                      onChange={(e) =>
+                        handleCategoryCheckboxChange("button", e.target.checked)
+                      }
+                      checked={
+                        getCategorySettingsFromMode(
+                          settings.elementTypeMode,
+                          defaultCustomCategorySettings,
+                        ).button
+                      }
+                      disabled={disabled || !settings.accessibilityInfo}
+                    >
+                      <span className="text-sm">{t("settings.buttons")}</span>
+                    </Checkbox>
+                    <Checkbox
+                      onChange={(e) =>
+                        handleCategoryCheckboxChange("link", e.target.checked)
+                      }
+                      checked={
+                        getCategorySettingsFromMode(
+                          settings.elementTypeMode,
+                          defaultCustomCategorySettings,
+                        ).link
+                      }
+                      disabled={disabled || !settings.accessibilityInfo}
+                    >
+                      <span className="text-sm">{t("settings.links")}</span>
+                    </Checkbox>
+                    <Checkbox
+                      onChange={(e) =>
+                        handleCategoryCheckboxChange(
+                          "section",
+                          e.target.checked,
+                        )
+                      }
+                      checked={
+                        getCategorySettingsFromMode(
+                          settings.elementTypeMode,
+                          defaultCustomCategorySettings,
+                        ).section
+                      }
+                      disabled={disabled || !settings.accessibilityInfo}
+                    >
+                      <span className="text-sm">{t("settings.sections")}</span>
+                    </Checkbox>
+                    <Checkbox
+                      onChange={(e) =>
+                        handleCategoryCheckboxChange("page", e.target.checked)
+                      }
+                      checked={
+                        getCategorySettingsFromMode(
+                          settings.elementTypeMode,
+                          defaultCustomCategorySettings,
+                        ).page
+                      }
+                      disabled={disabled || !settings.accessibilityInfo}
+                    >
+                      <span className="text-sm">{t("settings.page")}</span>
+                    </Checkbox>
+                    <Checkbox
+                      onChange={(e) =>
+                        handleCategoryCheckboxChange("lang", e.target.checked)
+                      }
+                      checked={
+                        getCategorySettingsFromMode(
+                          settings.elementTypeMode,
+                          defaultCustomCategorySettings,
+                        ).lang
+                      }
+                      disabled={disabled || !settings.accessibilityInfo}
+                    >
+                      <span className="text-sm">{t("settings.lang")}</span>
+                    </Checkbox>
+                    <Checkbox
+                      onChange={(e) =>
+                        handleCategoryCheckboxChange("table", e.target.checked)
+                      }
+                      checked={
+                        getCategorySettingsFromMode(
+                          settings.elementTypeMode,
+                          defaultCustomCategorySettings,
+                        ).table
+                      }
+                      disabled={disabled || !settings.accessibilityInfo}
+                    >
+                      <span className="text-sm">{t("settings.tables")}</span>
+                    </Checkbox>
+                    <Checkbox
+                      onChange={(e) =>
+                        handleCategoryCheckboxChange("list", e.target.checked)
+                      }
+                      checked={
+                        getCategorySettingsFromMode(
+                          settings.elementTypeMode,
+                          defaultCustomCategorySettings,
+                        ).list
+                      }
+                      disabled={disabled || !settings.accessibilityInfo}
+                    >
+                      <span className="text-sm">{t("settings.lists")}</span>
+                    </Checkbox>
+                  </div>
+                </fieldset>
+              </div>
+            )}
           </div>
           <div className="flex flex-col gap-2 px-2">
             <Checkbox

--- a/apps/browser_extension/src/i18n/en.json
+++ b/apps/browser_extension/src/i18n/en.json
@@ -45,8 +45,7 @@
     "basic": "Basic",
     "structure": "Structure",
     "content": "Content",
-    "custom": "Custom",
-    "selectedMessage": "Preset \"{{preset}}\" is selected"
+    "custom": "Custom"
   },
   "tip": {
     "name": "Name",

--- a/apps/browser_extension/src/i18n/en.json
+++ b/apps/browser_extension/src/i18n/en.json
@@ -41,6 +41,13 @@
     "displaySettings": "Display Settings",
     "displayCustomization": "Display Customization"
   },
+  "presets": {
+    "basic": "Basic",
+    "structure": "Structure",
+    "content": "Content",
+    "custom": "Custom",
+    "selectedMessage": "Preset \"{{preset}}\" is selected"
+  },
   "tip": {
     "name": "Name",
     "role": "Role",

--- a/apps/browser_extension/src/i18n/ja.json
+++ b/apps/browser_extension/src/i18n/ja.json
@@ -45,8 +45,7 @@
     "basic": "基本",
     "structure": "構造",
     "content": "コンテンツ",
-    "custom": "カスタム",
-    "selectedMessage": "プリセット「{{preset}}」が選択されています"
+    "custom": "カスタム"
   },
   "tip": {
     "name": "名前",

--- a/apps/browser_extension/src/i18n/ja.json
+++ b/apps/browser_extension/src/i18n/ja.json
@@ -41,6 +41,13 @@
     "displaySettings": "表示設定",
     "displayCustomization": "表示のカスタマイズ"
   },
+  "presets": {
+    "basic": "基本",
+    "structure": "構造",
+    "content": "コンテンツ",
+    "custom": "カスタム",
+    "selectedMessage": "プリセット「{{preset}}」が選択されています"
+  },
   "tip": {
     "name": "名前",
     "role": "ロール",

--- a/apps/browser_extension/src/i18n/ko.json
+++ b/apps/browser_extension/src/i18n/ko.json
@@ -41,6 +41,13 @@
     "displaySettings": "표시 설정",
     "displayCustomization": "표시 커스터마이징"
   },
+  "presets": {
+    "basic": "기본",
+    "structure": "구조",
+    "content": "콘텐츠",
+    "custom": "사용자 정의",
+    "selectedMessage": "프리셋 \"{{preset}}\"이 선택되었습니다"
+  },
   "tip": {
     "name": "이름",
     "role": "롤(역할)",

--- a/apps/browser_extension/src/i18n/ko.json
+++ b/apps/browser_extension/src/i18n/ko.json
@@ -45,8 +45,7 @@
     "basic": "기본",
     "structure": "구조",
     "content": "콘텐츠",
-    "custom": "사용자 정의",
-    "selectedMessage": "프리셋 \"{{preset}}\"이 선택되었습니다"
+    "custom": "사용자 정의"
   },
   "tip": {
     "name": "이름",

--- a/apps/browser_extension/src/settings/constatns.ts
+++ b/apps/browser_extension/src/settings/constatns.ts
@@ -1,22 +1,25 @@
-import { Settings } from "./types";
+import { Settings, CategorySettings } from "./types";
 
 export const DEFAULT_SETTING_KEY = "__default__";
 export const OBSOLETE_SETTING_KEY = "settings";
 export const FILE_SETTING_KEY = "__file__";
 
-export const initialSettings: Settings = {
-  accessibilityInfo: true,
+export const defaultCustomCategorySettings: CategorySettings = {
+  heading: true,
   image: true,
   formControl: true,
-  link: false,
   button: true,
-  heading: true,
-  ariaHidden: true,
-  section: true,
-  lang: true,
+  link: true,
+  ariaHidden: false,
+  section: false,
   page: true,
+  lang: true,
   table: false,
-  list: true,
+  list: false,
+} as const;
+
+export const initialSettings: Settings = {
+  accessibilityInfo: true,
   interactiveMode: true,
   hideTips: true,
   showLiveRegions: true,
@@ -26,4 +29,8 @@ export const initialSettings: Settings = {
   liveRegionOpacityPercent: 50,
   tipFontSize: 10,
   liveRegionFontSize: 48,
+  elementTypeMode: {
+    mode: "preset",
+    presetId: "basic",
+  },
 } as const;

--- a/apps/browser_extension/src/settings/presets.ts
+++ b/apps/browser_extension/src/settings/presets.ts
@@ -1,0 +1,89 @@
+import { CategorySettings, PresetId } from "./types";
+
+export interface Preset {
+  id: Exclude<PresetId, "custom">;
+  labelKey: string;
+  settings: CategorySettings;
+}
+
+export const presets: Preset[] = [
+  {
+    id: "basic",
+    labelKey: "presets.basic",
+    settings: {
+      heading: true,
+      image: true,
+      formControl: true,
+      button: true,
+      link: true,
+      ariaHidden: false,
+      section: false,
+      page: true,
+      lang: true,
+      table: false,
+      list: false,
+    },
+  },
+  {
+    id: "structure",
+    labelKey: "presets.structure",
+    settings: {
+      heading: true,
+      image: false,
+      formControl: false,
+      button: false,
+      link: false,
+      ariaHidden: false,
+      section: true,
+      page: true,
+      lang: true,
+      table: false,
+      list: false,
+    },
+  },
+  {
+    id: "content",
+    labelKey: "presets.content",
+    settings: {
+      heading: false,
+      image: true,
+      formControl: false,
+      button: false,
+      link: true,
+      ariaHidden: false,
+      section: false,
+      page: false,
+      lang: false,
+      table: true,
+      list: true,
+    },
+  },
+];
+
+export function getCategorySettingsFromMode(
+  elementTypeMode: import("./types").ElementTypeMode,
+  defaultCustomSettings: CategorySettings,
+): CategorySettings {
+  if (elementTypeMode.mode === "preset") {
+    const preset = presets.find((p) => p.id === elementTypeMode.presetId);
+    return preset ? preset.settings : defaultCustomSettings;
+  } else {
+    return elementTypeMode.settings;
+  }
+}
+
+export function getPresetFromCategorySettings(
+  categorySettings: CategorySettings,
+): Exclude<PresetId, "custom"> | null {
+  for (const preset of presets) {
+    const matches = Object.entries(preset.settings).every(([key, value]) => {
+      return categorySettings[key as keyof CategorySettings] === value;
+    });
+
+    if (matches) {
+      return preset.id;
+    }
+  }
+
+  return null;
+}

--- a/apps/browser_extension/src/settings/storage.ts
+++ b/apps/browser_extension/src/settings/storage.ts
@@ -1,13 +1,86 @@
-import { Settings } from "./types";
+import { Settings, CategorySettings } from "./types";
 import {
   DEFAULT_SETTING_KEY,
   FILE_SETTING_KEY,
   initialSettings,
+  defaultCustomCategorySettings,
 } from "./constatns";
 import { getAsync, removeAsync, setAsync } from "../browser/localStorage";
 
+// 古い形式の設定を新しい形式に変換
+function migrateLegacySettings(settings: unknown): Settings {
+  const settingsObj = settings as Record<string, unknown>;
+  // 古い形式には elementTypeMode がない場合
+  if (!settingsObj.elementTypeMode) {
+    const categorySettings: CategorySettings = {
+      image:
+        (settingsObj.image as boolean) ?? defaultCustomCategorySettings.image,
+      formControl:
+        (settingsObj.formControl as boolean) ??
+        defaultCustomCategorySettings.formControl,
+      link: (settingsObj.link as boolean) ?? defaultCustomCategorySettings.link,
+      button:
+        (settingsObj.button as boolean) ?? defaultCustomCategorySettings.button,
+      heading:
+        (settingsObj.heading as boolean) ??
+        defaultCustomCategorySettings.heading,
+      ariaHidden:
+        (settingsObj.ariaHidden as boolean) ??
+        defaultCustomCategorySettings.ariaHidden,
+      section:
+        (settingsObj.section as boolean) ??
+        defaultCustomCategorySettings.section,
+      lang: (settingsObj.lang as boolean) ?? defaultCustomCategorySettings.lang,
+      page: (settingsObj.page as boolean) ?? defaultCustomCategorySettings.page,
+      table:
+        (settingsObj.table as boolean) ?? defaultCustomCategorySettings.table,
+      list: (settingsObj.list as boolean) ?? defaultCustomCategorySettings.list,
+    };
+
+    return {
+      accessibilityInfo:
+        (settingsObj.accessibilityInfo as boolean) ??
+        initialSettings.accessibilityInfo,
+      interactiveMode:
+        (settingsObj.interactiveMode as boolean) ??
+        initialSettings.interactiveMode,
+      hideTips: (settingsObj.hideTips as boolean) ?? initialSettings.hideTips,
+      showLiveRegions:
+        (settingsObj.showLiveRegions as boolean) ??
+        initialSettings.showLiveRegions,
+      announcementMaxSeconds:
+        (settingsObj.announcementMaxSeconds as number) ??
+        initialSettings.announcementMaxSeconds,
+      announcementSecondsPerCharacter:
+        (settingsObj.announcementSecondsPerCharacter as number) ??
+        initialSettings.announcementSecondsPerCharacter,
+      tipOpacityPercent:
+        (settingsObj.tipOpacityPercent as number) ??
+        initialSettings.tipOpacityPercent,
+      liveRegionOpacityPercent:
+        (settingsObj.liveRegionOpacityPercent as number) ??
+        initialSettings.liveRegionOpacityPercent,
+      tipFontSize:
+        (settingsObj.tipFontSize as number) ?? initialSettings.tipFontSize,
+      liveRegionFontSize:
+        (settingsObj.liveRegionFontSize as number) ??
+        initialSettings.liveRegionFontSize,
+      elementTypeMode: {
+        mode: "custom",
+        settings: categorySettings,
+      },
+    };
+  }
+
+  return settingsObj as Settings;
+}
+
 export const loadDefaultSettings = async (): Promise<[Settings, boolean]> => {
-  return await getAsync(DEFAULT_SETTING_KEY, initialSettings);
+  const [settings, found] = await getAsync(
+    DEFAULT_SETTING_KEY,
+    initialSettings,
+  );
+  return [migrateLegacySettings(settings), found];
 };
 
 export const loadUrlSettings = async (
@@ -17,12 +90,21 @@ export const loadUrlSettings = async (
   if (url) {
     const parsedURL = new URL(url);
     if (["http:", "https:"].includes(parsedURL.protocol) && parsedURL.host) {
-      return await getAsync(parsedURL.host, baseSettings);
+      const [settings, found] = await getAsync(parsedURL.host, baseSettings);
+      return [migrateLegacySettings(settings), found];
     }
     if (parsedURL.protocol === "file:") {
-      return await getAsync(FILE_SETTING_KEY, baseSettings);
+      const [settings, found] = await getAsync(FILE_SETTING_KEY, baseSettings);
+      return [migrateLegacySettings(settings), found];
     }
   }
+
+  // 初めて訪問するホストの場合、デフォルト設定がカスタムモードかチェック
+  if (baseSettings.elementTypeMode.mode === "custom") {
+    // すでにカスタムモードの場合、そのまま返す
+    return [baseSettings, false];
+  }
+
   return [baseSettings, false];
 };
 

--- a/apps/browser_extension/src/settings/types.ts
+++ b/apps/browser_extension/src/settings/types.ts
@@ -12,6 +12,18 @@ export type CategorySettings = {
   list: boolean;
 };
 
+export type PresetId = "basic" | "structure" | "content" | "custom";
+
+export type ElementTypeMode =
+  | {
+      mode: "preset";
+      presetId: Exclude<PresetId, "custom">;
+    }
+  | {
+      mode: "custom";
+      settings: CategorySettings;
+    };
+
 export type Settings = {
   accessibilityInfo: boolean;
   interactiveMode: boolean;
@@ -23,7 +35,8 @@ export type Settings = {
   liveRegionOpacityPercent: number;
   tipFontSize: number;
   liveRegionFontSize: number;
-} & CategorySettings;
+  elementTypeMode: ElementTypeMode;
+};
 
 export type SettingsMessage =
   | {


### PR DESCRIPTION
Introducing presets for easier accessibility testing.
I have been concerned about that users who are beginners at web accessibility will be confused about what to checked in the popup and what to look for. In this PR, added presets for common accessibility checks.

Presets are:

- Basic (Headings, Images, Form controls, Buttons, Links, Page, and Language)
- Structure (Headings, Sections, Page, and Language)
- Content (Images, Links, Tables, and Lists)
- Custom (same as before)

<img width="330" alt="Screenshot: the popup showing Basic tab, in Japanese" src="https://github.com/user-attachments/assets/f01043f2-a910-4058-8bdd-74d5d96940c7" />
