### PR TITLE
Enable status tips for aria-label and aria-labelledby

### DIFF
--- a/apps/browser_extension/src/rules/aria-attributes/index.ts
+++ b/apps/browser_extension/src/rules/aria-attributes/index.ts
@@ -37,8 +37,8 @@ const ariaAttributes = [
   // "aria-hidden", // handled by aria-hidden rule
   // "aria-invalid", // handled by aria-state rule
   "aria-keyshortcuts",
-  // "aria-label", // handled by accessible-name rule
-  // "aria-labelledby", // handled by accessible-name rule
+  "aria-label",
+  "aria-labelledby",
   "aria-level",
   "aria-live",
   "aria-modal",


### PR DESCRIPTION
aria-label and aria-labelledby are not handled by AriaAttributes rule, because they are handled by the accessible-name rule.

But I think that they should be shown as status tip, because;

- For many situations, there are more better way for naming that are not using explicit WAI-ARIA semantics, using implicit one by host language
- Sometimes id reference of aria-labelledby are wrong, and if its value were shown, it is useful to know why the name is wrong