### PR TITLE
Change test setting not to save screenshots

### DIFF
--- a/apps/browser_extension/vite.test.config.ts
+++ b/apps/browser_extension/vite.test.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       enabled: true,
       provider: "playwright",
       headless: true,
+      screenshot: false,
       instances: [
         {
           name: "chromium",


### PR DESCRIPTION
Screenshots had been saved in `__screenshots__` directory on the test file when it failed.
It is not need because we use vitest only for unit testing.