### PR TITLE
Show invalid WAI-ARIA attribute value

### DIFF
--- a/apps/browser_extension/entrypoints/content/components/RuleTip.tsx
+++ b/apps/browser_extension/entrypoints/content/components/RuleTip.tsx
@@ -186,13 +186,11 @@ export const RuleTip = ({
     >
       <Icon type={result.type} />
       {!hideLabel &&
-        (result.type === "error"
-          ? t(result.message)
-          : result.type === "warning"
-            ? t(result.message)
-            : result.type === "state"
-              ? t(result.state)
-              : `${result.contentLabel ? t(result.contentLabel) : ""} ${t(result.content)}`)}
+        (result.type === "error" || result.type === "warning"
+          ? t(result.message, result.messageParams)
+          : result.type === "state"
+            ? t(result.state)
+            : `${result.contentLabel ? t(result.contentLabel) : ""} ${t(result.content)}`)}
     </div>
   );
 };

--- a/apps/browser_extension/src/i18n/en.json
+++ b/apps/browser_extension/src/i18n/en.json
@@ -92,6 +92,8 @@
   "aria-hidden": "aria-hidden",
   "Invalid WAI-ARIA attribute value": "Invalid WAI-ARIA attribute value",
   "Invalid role for WAI-ARIA attribute": "Invalid role for WAI-ARIA attribute",
+  "Invalid WAI-ARIA attribute value: {{attribute}}": "Invalid WAI-ARIA attribute value: {{attribute}}",
+  "Invalid role for WAI-ARIA attribute: {{attribute}}": "Invalid role for WAI-ARIA attribute: {{attribute}}",
   "Not focusable": "Not focusable",
   "No accessible name": "No accessible name",
   "No heading level": "No heading level",

--- a/apps/browser_extension/src/i18n/ja.json
+++ b/apps/browser_extension/src/i18n/ja.json
@@ -92,6 +92,8 @@
   "aria-hidden": "aria-hidden",
   "Invalid WAI-ARIA attribute value": "WAI-ARIA属性値が不正",
   "Invalid role for WAI-ARIA attribute": "WAI-ARIA属性を使用できないロール",
+  "Invalid WAI-ARIA attribute value: {{attribute}}": "WAI-ARIA属性値が不正: {{attribute}}",
+  "Invalid role for WAI-ARIA attribute: {{attribute}}": "WAI-ARIA属性を使用できないロール: {{attribute}}",
   "Not focusable": "フォーカスできない",
   "No accessible name": "名前（ラベル）なし",
   "No heading level": "見出しレベルなし",

--- a/apps/browser_extension/src/i18n/ko.json
+++ b/apps/browser_extension/src/i18n/ko.json
@@ -90,8 +90,10 @@
     "definitionList": "Definition list"
   },
   "aria-hidden": "aria-hidden",
-  "Invalid WAI-ARIA attribute value": "Invalid WAI-ARIA attribute value",
-  "Invalid role for WAI-ARIA attribute": "Invalid role for WAI-ARIA attribute",
+  "Invalid WAI-ARIA attribute value": "WAI-ARIA 속성 값 오류",
+  "Invalid role for WAI-ARIA attribute": "WAI-ARIA 속성을 사용할 수 없는 역할",
+  "Invalid WAI-ARIA attribute value: {{attribute}}": "WAI-ARIA 속성 값 오류: {{attribute}}",
+  "Invalid role for WAI-ARIA attribute: {{attribute}}": "WAI-ARIA 속성을 사용할 수 없는 역할: {{attribute}}",
   "Not focusable": "포커싱 불가",
   "No accessible name": "이름(레이블) 없음",
   "No heading level": "헤딩 레벨 없음",

--- a/apps/browser_extension/src/rules/Rules.ts
+++ b/apps/browser_extension/src/rules/Rules.ts
@@ -2,6 +2,7 @@ import { AccessibleDescription } from "./accessible-description";
 import { AccessibleName } from "./accessible-name";
 import { AriaAttributes } from "./aria-attributes";
 import { AriaState } from "./aria-state";
+import { AriaValidation } from "./aria-validation";
 import { ControlFocus } from "./control-focus";
 import { ControlName } from "./control-name";
 import { Fieldset } from "./fieldset";
@@ -54,6 +55,7 @@ export const Rules = [
   Role,
   ListItem,
   AriaState,
+  AriaValidation,
   AriaAttributes,
   AccessibleDescription,
 ] as const;

--- a/apps/browser_extension/src/rules/aria-attributes/index.ts
+++ b/apps/browser_extension/src/rules/aria-attributes/index.ts
@@ -65,6 +65,9 @@ const ariaAttributes = [
   "aria-valuetext",
 ] as const;
 
+/**
+ * WAI-ARIA属性の値をすべて表示する
+ */
 export const AriaAttributes: RuleObject = {
   ruleName,
   defaultOptions,

--- a/apps/browser_extension/src/rules/aria-state/index.test.ts
+++ b/apps/browser_extension/src/rules/aria-state/index.test.ts
@@ -1,17 +1,5 @@
 import { describe, test, expect, afterEach } from "vitest";
 import { AriaState } from ".";
-
-const invalidValueError = {
-  type: "error",
-  ruleName: "aria-state",
-  message: "Invalid WAI-ARIA attribute value",
-};
-
-const invalidRoleError = {
-  type: "error",
-  ruleName: "aria-state",
-  message: "Invalid role for WAI-ARIA attribute",
-};
 describe("aria-state", () => {
   afterEach(() => {
     document.body.innerHTML = "";
@@ -52,12 +40,12 @@ describe("aria-state", () => {
     ]);
   });
 
-  test('aria-busy="invalid"', () => {
+  test('aria-busy="invalid" - no validation (handled by AriaValidation)', () => {
     const element = document.createElement("div");
     element.setAttribute("aria-busy", "invalid");
     document.body.appendChild(element);
     const result = AriaState.evaluate(element, { enabled: true }, {});
-    expect(result).toEqual([invalidValueError]);
+    expect(result).toBeUndefined();
   });
 
   test('aria-current="page"', () => {
@@ -74,12 +62,12 @@ describe("aria-state", () => {
     ]);
   });
 
-  test('aria-current="invalid"', () => {
+  test('aria-current="invalid" - no validation (handled by AriaValidation)', () => {
     const element = document.createElement("div");
     element.setAttribute("aria-current", "invalid");
     document.body.appendChild(element);
     const result = AriaState.evaluate(element, { enabled: true }, {});
-    expect(result).toEqual([invalidValueError]);
+    expect(result).toBeUndefined();
   });
 
   test('aria-checked="true"', () => {
@@ -97,13 +85,13 @@ describe("aria-state", () => {
     ]);
   });
 
-  test('aria-checked="true" (role is invalid)', () => {
+  test('aria-checked="true" (role is invalid) - no validation (handled by AriaValidation)', () => {
     const element = document.createElement("div");
     element.setAttribute("role", "button");
     element.setAttribute("aria-checked", "true");
     document.body.appendChild(element);
     const result = AriaState.evaluate(element, { enabled: true }, {});
-    expect(result).toEqual([invalidRoleError]);
+    expect(result).toBeUndefined();
   });
 
   test("checkbox", () => {
@@ -391,26 +379,24 @@ describe("aria-state", () => {
     });
   });
 
-  test("multiple errors", () => {
+  test("multiple valid states (no validation errors)", () => {
     const element = document.createElement("div");
     element.setAttribute("role", "button");
-    element.setAttribute("aria-busy", "invalid");
-    element.setAttribute("aria-current", "invalid");
-    element.setAttribute("aria-checked", "true");
-    element.setAttribute("aria-selected", "true");
+    element.setAttribute("aria-busy", "true");
+    element.setAttribute("aria-current", "page");
     element.setAttribute("aria-disabled", "true");
     document.body.appendChild(element);
     const result = AriaState.evaluate(element, { enabled: true }, {});
     expect(result).toHaveLength(3);
     expect(result).toContainEqual({
-      type: "error",
+      type: "state",
       ruleName: "aria-state",
-      message: "Invalid WAI-ARIA attribute value",
+      state: "Busy: true",
     });
     expect(result).toContainEqual({
-      type: "error",
+      type: "state",
       ruleName: "aria-state",
-      message: "Invalid WAI-ARIA attribute value",
+      state: "Current: page",
     });
     expect(result).toContainEqual({
       type: "state",

--- a/apps/browser_extension/src/rules/aria-validation/ariaSpec.ts
+++ b/apps/browser_extension/src/rules/aria-validation/ariaSpec.ts
@@ -1,0 +1,483 @@
+/**
+ * WAI-ARIA 1.2 specification data
+ *
+ * This file contains the complete WAI-ARIA specification data used by multiple rules:
+ * - AriaValidation rule: Validates all ARIA attributes for value and role compatibility
+ * - AriaState rule: Uses subset of attributes for display purposes
+ */
+
+import { KnownRole } from "../../dom/getKnownRole";
+
+// ============================================================================
+// ALL ARIA ATTRIBUTES
+// ============================================================================
+
+/**
+ * All ARIA attributes defined in WAI-ARIA 1.2 specification.
+ * This is the single source of truth for all ARIA attributes.
+ */
+export const ALL_ARIA_ATTRIBUTES = [
+  "aria-activedescendant",
+  "aria-atomic",
+  "aria-autocomplete",
+  "aria-braillelabel",
+  "aria-brailleroledescription",
+  "aria-busy",
+  "aria-checked",
+  "aria-colcount",
+  "aria-colindex",
+  "aria-colindextext",
+  "aria-colspan",
+  "aria-controls",
+  "aria-current",
+  "aria-describedby",
+  "aria-description",
+  "aria-details",
+  "aria-disabled",
+  "aria-dropeffect",
+  "aria-errormessage",
+  "aria-expanded",
+  "aria-flowto",
+  "aria-grabbed",
+  "aria-haspopup",
+  "aria-hidden",
+  "aria-invalid",
+  "aria-keyshortcuts",
+  "aria-label",
+  "aria-labelledby",
+  "aria-level",
+  "aria-live",
+  "aria-modal",
+  "aria-multiline",
+  "aria-multiselectable",
+  "aria-orientation",
+  "aria-owns",
+  "aria-placeholder",
+  "aria-posinset",
+  "aria-pressed",
+  "aria-readonly",
+  "aria-relevant",
+  "aria-required",
+  "aria-roledescription",
+  "aria-rowcount",
+  "aria-rowindex",
+  "aria-rowindextext",
+  "aria-rowspan",
+  "aria-selected",
+  "aria-setsize",
+  "aria-sort",
+  "aria-valuemax",
+  "aria-valuemin",
+  "aria-valuenow",
+  "aria-valuetext",
+] as const;
+
+export type AriaAttribute = (typeof ALL_ARIA_ATTRIBUTES)[number];
+
+// ============================================================================
+// VALID VALUES FOR ARIA ATTRIBUTES
+// ============================================================================
+
+/**
+ * Valid values for all ARIA attributes.
+ * Used by both AriaState (for display) and AriaValidation (for validation).
+ */
+export const ARIA_ATTRIBUTE_VALUES: Record<
+  AriaAttribute,
+  string[] | "any" | "id-reference" | "id-reference-list" | "integer" | "number"
+> = {
+  "aria-activedescendant": "id-reference",
+  "aria-atomic": ["true", "false"],
+  "aria-autocomplete": ["none", "inline", "list", "both"],
+  "aria-braillelabel": "any",
+  "aria-brailleroledescription": "any",
+  "aria-busy": ["true", "false"],
+  "aria-checked": ["true", "false", "mixed", "undefined"],
+  "aria-colcount": "integer",
+  "aria-colindex": "integer",
+  "aria-colindextext": "any",
+  "aria-colspan": "integer",
+  "aria-controls": "id-reference-list",
+  "aria-current": ["true", "false", "page", "step", "location", "date", "time"],
+  "aria-describedby": "id-reference-list",
+  "aria-description": "any",
+  "aria-details": "id-reference",
+  "aria-disabled": ["true", "false"],
+  "aria-dropeffect": ["none", "copy", "execute", "link", "move", "popup"],
+  "aria-errormessage": "id-reference",
+  "aria-expanded": ["true", "false", "undefined"],
+  "aria-flowto": "id-reference-list",
+  "aria-grabbed": ["true", "false", "undefined"],
+  "aria-haspopup": [
+    "false",
+    "true",
+    "menu",
+    "listbox",
+    "tree",
+    "grid",
+    "dialog",
+  ],
+  "aria-hidden": ["true", "false"],
+  "aria-invalid": ["true", "false", "grammar", "spelling"],
+  "aria-keyshortcuts": "any",
+  "aria-label": "any",
+  "aria-labelledby": "id-reference-list",
+  "aria-level": "integer",
+  "aria-live": ["off", "polite", "assertive"],
+  "aria-modal": ["true", "false"],
+  "aria-multiline": ["true", "false"],
+  "aria-multiselectable": ["true", "false"],
+  "aria-orientation": ["horizontal", "vertical", "undefined"],
+  "aria-owns": "id-reference-list",
+  "aria-placeholder": "any",
+  "aria-posinset": "integer",
+  "aria-pressed": ["true", "false", "mixed", "undefined"],
+  "aria-readonly": ["true", "false"],
+  "aria-relevant": ["additions", "removals", "text", "all"],
+  "aria-required": ["true", "false"],
+  "aria-roledescription": "any",
+  "aria-rowcount": "integer",
+  "aria-rowindex": "integer",
+  "aria-rowindextext": "any",
+  "aria-rowspan": "integer",
+  "aria-selected": ["true", "false", "undefined"],
+  "aria-setsize": "integer",
+  "aria-sort": ["none", "ascending", "descending", "other"],
+  "aria-valuemax": "number",
+  "aria-valuemin": "number",
+  "aria-valuenow": "number",
+  "aria-valuetext": "any",
+} as const;
+
+// ============================================================================
+// ROLE COMPATIBILITY
+// ============================================================================
+
+/**
+ * Roles that can use each ARIA attribute.
+ * Used by AriaValidation rule for role compatibility validation.
+ */
+export const ARIA_ATTRIBUTE_ROLES: Record<AriaAttribute, KnownRole[] | "all"> =
+  {
+    "aria-activedescendant": [
+      "application",
+      "combobox",
+      "composite",
+      "group",
+      "textbox",
+      "columnheader",
+      "grid",
+      "gridcell",
+      "listbox",
+      "menu",
+      "menubar",
+      "radiogroup",
+      "row",
+      "rowheader",
+      "searchbox",
+      "select",
+      "tablist",
+      "tree",
+      "treegrid",
+      "treeitem",
+    ],
+    "aria-atomic": "all", // global
+    "aria-autocomplete": ["combobox", "textbox", "searchbox"],
+    "aria-braillelabel": "all", // global
+    "aria-brailleroledescription": "all", // global
+    "aria-busy": "all", // global
+    "aria-checked": [
+      "checkbox",
+      "menuitemcheckbox",
+      "option",
+      "radio",
+      "switch",
+      "menuitemradio",
+      "treeitem",
+    ],
+    "aria-colcount": ["table", "grid", "treegrid"],
+    "aria-colindex": ["cell", "columnheader", "gridcell", "row", "rowheader"],
+    "aria-colindextext": [
+      "cell",
+      "columnheader",
+      "gridcell",
+      "row",
+      "rowheader",
+    ],
+    "aria-colspan": ["cell", "columnheader", "gridcell", "rowheader"],
+    "aria-controls": "all", // global
+    "aria-current": "all", // global
+    "aria-describedby": "all", // global
+    "aria-description": "all", // global
+    "aria-details": "all", // global
+    "aria-disabled": [
+      "application",
+      "button",
+      "composite",
+      "gridcell",
+      "group",
+      "input",
+      "link",
+      "menuitem",
+      "scrollbar",
+      "separator",
+      "tab",
+      "checkbox",
+      "columnheader",
+      "combobox",
+      "grid",
+      "listbox",
+      "menu",
+      "menubar",
+      "menuitemcheckbox",
+      "menuitemradio",
+      "option",
+      "radio",
+      "radiogroup",
+      "row",
+      "rowheader",
+      "searchbox",
+      "select",
+      "slider",
+      "spinbutton",
+      "switch",
+      "tablist",
+      "textbox",
+      "toolbar",
+      "tree",
+      "treegrid",
+      "treeitem",
+    ],
+    "aria-dropeffect": "all", // global (deprecated)
+    "aria-errormessage": "all", // global
+    "aria-expanded": [
+      "application",
+      "button",
+      "checkbox",
+      "combobox",
+      "gridcell",
+      "link",
+      "listbox",
+      "menuitem",
+      "row",
+      "rowheader",
+      "tab",
+      "treeitem",
+      "columnheader",
+      "menuitemcheckbox",
+      "menuitemradio",
+      "switch",
+    ],
+    "aria-flowto": "all", // global
+    "aria-grabbed": "all", // global (deprecated)
+    "aria-haspopup": "all", // global
+    "aria-hidden": "all", // global
+    "aria-invalid": [
+      "application",
+      "checkbox",
+      "combobox",
+      "gridcell",
+      "listbox",
+      "radiogroup",
+      "slider",
+      "spinbutton",
+      "textbox",
+      "tree",
+      "columnheader",
+      "rowheader",
+      "searchbox",
+      "switch",
+      "treegrid",
+    ],
+    "aria-keyshortcuts": "all", // global
+    "aria-label": "all", // global
+    "aria-labelledby": "all", // global
+    "aria-level": ["heading", "listitem", "row", "treeitem"],
+    "aria-live": "all", // global
+    "aria-modal": ["dialog"],
+    "aria-multiline": ["textbox", "searchbox"],
+    "aria-multiselectable": ["grid", "listbox", "tablist", "tree", "treegrid"],
+    "aria-orientation": [
+      "scrollbar",
+      "select",
+      "separator",
+      "slider",
+      "tablist",
+      "toolbar",
+      "listbox",
+      "menu",
+      "menubar",
+      "radiogroup",
+      "tree",
+      "treegrid",
+    ],
+    "aria-owns": "all", // global
+    "aria-placeholder": ["textbox", "searchbox"],
+    "aria-posinset": [
+      "article",
+      "listitem",
+      "menuitem",
+      "option",
+      "radio",
+      "tab",
+      "menuitemcheckbox",
+      "menuitemradio",
+      "treeitem",
+    ],
+    "aria-pressed": ["button"],
+    "aria-readonly": [
+      "checkbox",
+      "combobox",
+      "grid",
+      "gridcell",
+      "listbox",
+      "radiogroup",
+      "slider",
+      "spinbutton",
+      "textbox",
+      "columnheader",
+      "rowheader",
+      "searchbox",
+      "switch",
+      "treegrid",
+    ],
+    "aria-relevant": "all", // global
+    "aria-required": [
+      "checkbox",
+      "combobox",
+      "gridcell",
+      "listbox",
+      "radiogroup",
+      "spinbutton",
+      "textbox",
+      "tree",
+      "columnheader",
+      "rowheader",
+      "searchbox",
+      "switch",
+      "treegrid",
+    ],
+    "aria-roledescription": "all", // global
+    "aria-rowcount": ["table", "grid", "treegrid"],
+    "aria-rowindex": ["cell", "row", "columnheader", "gridcell", "rowheader"],
+    "aria-rowindextext": [
+      "cell",
+      "row",
+      "columnheader",
+      "gridcell",
+      "rowheader",
+    ],
+    "aria-rowspan": ["cell", "columnheader", "gridcell", "rowheader"],
+    "aria-selected": [
+      "gridcell",
+      "option",
+      "row",
+      "tab",
+      "columnheader",
+      "rowheader",
+      "treeitem",
+    ],
+    "aria-setsize": [
+      "article",
+      "listitem",
+      "menuitem",
+      "option",
+      "radio",
+      "tab",
+      "menuitemcheckbox",
+      "menuitemradio",
+      "treeitem",
+    ],
+    "aria-sort": ["columnheader", "rowheader"],
+    "aria-valuemax": [
+      "progressbar",
+      "scrollbar",
+      "separator",
+      "slider",
+      "spinbutton",
+    ],
+    "aria-valuemin": [
+      "progressbar",
+      "scrollbar",
+      "separator",
+      "slider",
+      "spinbutton",
+    ],
+    "aria-valuenow": [
+      "progressbar",
+      "scrollbar",
+      "separator",
+      "slider",
+      "spinbutton",
+    ],
+    "aria-valuetext": [
+      "progressbar",
+      "scrollbar",
+      "separator",
+      "slider",
+      "spinbutton",
+    ],
+  } as const;
+
+// ============================================================================
+// VALIDATION HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Validates the value of any ARIA attribute.
+ */
+export const validateAriaAttributeValue = (
+  attribute: AriaAttribute,
+  value: string,
+): boolean => {
+  const validValues = ARIA_ATTRIBUTE_VALUES[attribute];
+
+  if (validValues === "any") {
+    return value.trim().length > 0;
+  }
+
+  if (validValues === "id-reference") {
+    return /^[a-zA-Z][\w\-_:.]*$/.test(value.trim());
+  }
+
+  if (validValues === "id-reference-list") {
+    const ids = value.trim().split(/\s+/);
+    return ids.every((id) => /^[a-zA-Z][\w\-_:.]*$/.test(id));
+  }
+
+  if (validValues === "integer") {
+    const num = parseInt(value.trim(), 10);
+    return !isNaN(num) && num.toString() === value.trim() && num >= 1;
+  }
+
+  if (validValues === "number") {
+    const num = parseFloat(value.trim());
+    return !isNaN(num) && isFinite(num);
+  }
+
+  if (Array.isArray(validValues)) {
+    return validValues.includes(value.trim());
+  }
+
+  return false;
+};
+
+/**
+ * Checks if an ARIA attribute is valid for the given role.
+ */
+export const isValidAriaAttributeForRole = (
+  attribute: AriaAttribute,
+  role: KnownRole | null,
+): boolean => {
+  const validRoles = ARIA_ATTRIBUTE_ROLES[attribute];
+
+  if (validRoles === "all") {
+    return true;
+  }
+
+  if (!role) {
+    return false;
+  }
+
+  return (validRoles as KnownRole[]).includes(role);
+};

--- a/apps/browser_extension/src/rules/aria-validation/index.test.ts
+++ b/apps/browser_extension/src/rules/aria-validation/index.test.ts
@@ -1,0 +1,222 @@
+import { describe, test, expect, afterEach } from "vitest";
+import { AriaValidation } from "./index";
+
+describe("AriaValidation", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("validates aria-label with valid value", () => {
+    document.body.innerHTML = `<div role="button" aria-label="Click me">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("reports error for invalid aria-haspopup value with attribute name", () => {
+    document.body.innerHTML = `<div role="button" aria-haspopup="invalid">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toHaveLength(1);
+    expect(result![0]).toEqual({
+      type: "error",
+      message: "Invalid WAI-ARIA attribute value: {{attribute}}",
+      messageParams: { attribute: "aria-haspopup" },
+      ruleName: "aria-validation",
+    });
+  });
+
+  test("reports error for aria-level on invalid role with attribute and role name", () => {
+    document.body.innerHTML = `<div role="button" aria-level="2">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toHaveLength(1);
+    expect(result![0]).toEqual({
+      type: "error",
+      message: "Invalid role for WAI-ARIA attribute: {{attribute}}",
+      messageParams: { attribute: "aria-level" },
+      ruleName: "aria-validation",
+    });
+  });
+
+  test("validates aria-level on valid role", () => {
+    document.body.innerHTML = `<div role="heading" aria-level="2">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("validates integer attributes", () => {
+    document.body.innerHTML = `<div role="grid" aria-colcount="5">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("reports error for invalid integer value with attribute name", () => {
+    document.body.innerHTML = `<div role="grid" aria-colcount="not-a-number">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toHaveLength(1);
+    expect(result![0]).toEqual({
+      type: "error",
+      message: "Invalid WAI-ARIA attribute value: {{attribute}}",
+      messageParams: { attribute: "aria-colcount" },
+      ruleName: "aria-validation",
+    });
+  });
+
+  test("skips aria-hidden validation (handled by AriaAttributes)", () => {
+    document.body.innerHTML = `<div aria-hidden="true">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("validates id-reference-list attributes", () => {
+    document.body.innerHTML = `<div aria-describedby="desc1 desc2 desc3">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("reports error for invalid id-reference-list with attribute name", () => {
+    document.body.innerHTML = `<div aria-describedby="123invalid">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toHaveLength(1);
+    expect(result![0]).toEqual({
+      type: "error",
+      message: "Invalid WAI-ARIA attribute value: {{attribute}}",
+      messageParams: { attribute: "aria-describedby" },
+      ruleName: "aria-validation",
+    });
+  });
+
+  test("returns undefined when disabled", () => {
+    document.body.innerHTML = `<div role="button" aria-haspopup="invalid">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(element, { enabled: false }, {});
+    expect(result).toBeUndefined();
+  });
+
+  test("ignores elements without aria attributes", () => {
+    document.body.innerHTML = `<div role="button">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("validates multiple attributes with mixed results", () => {
+    document.body.innerHTML = `<div role="button" aria-label="Valid" aria-haspopup="invalid">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toHaveLength(1);
+    expect(result![0]).toEqual({
+      type: "error",
+      message: "Invalid WAI-ARIA attribute value: {{attribute}}",
+      messageParams: { attribute: "aria-haspopup" },
+      ruleName: "aria-validation",
+    });
+  });
+
+  test("validates AriaState attributes - valid aria-checked", () => {
+    document.body.innerHTML = `<div role="checkbox" aria-checked="true">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("reports error for invalid AriaState attribute value", () => {
+    document.body.innerHTML = `<div role="checkbox" aria-checked="invalid">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toHaveLength(1);
+    expect(result![0]).toEqual({
+      type: "error",
+      message: "Invalid WAI-ARIA attribute value: {{attribute}}",
+      messageParams: { attribute: "aria-checked" },
+      ruleName: "aria-validation",
+    });
+  });
+
+  test("reports error for AriaState attribute on invalid role", () => {
+    document.body.innerHTML = `<div role="heading" aria-checked="true">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toHaveLength(1);
+    expect(result![0]).toEqual({
+      type: "error",
+      message: "Invalid role for WAI-ARIA attribute: {{attribute}}",
+      messageParams: { attribute: "aria-checked" },
+      ruleName: "aria-validation",
+    });
+  });
+
+  test("validates global AriaState attributes on any role", () => {
+    document.body.innerHTML = `<div role="button" aria-busy="true">Content</div>`;
+    const element = document.querySelector("div")!;
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+});

--- a/apps/browser_extension/src/rules/aria-validation/index.ts
+++ b/apps/browser_extension/src/rules/aria-validation/index.ts
@@ -1,0 +1,68 @@
+import { getKnownRole } from "../../dom/getKnownRole";
+import { RuleObject, RuleResult } from "../type";
+import {
+  ALL_ARIA_ATTRIBUTES,
+  validateAriaAttributeValue,
+  isValidAriaAttributeForRole,
+} from "./ariaSpec";
+
+type Options = {
+  enabled: boolean;
+};
+
+const ruleName = "aria-validation";
+const defaultOptions = { enabled: true };
+
+/**
+ * Validates all WAI-ARIA attributes for value validity and role compatibility
+ * Handles both AriaState attributes (native duplicates) and AriaValidation attributes
+ */
+export const AriaValidation: RuleObject = {
+  ruleName,
+  defaultOptions,
+  evaluate: (element: Element, { enabled }: Options = defaultOptions) => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    const results: RuleResult[] = [];
+    const role = getKnownRole(element);
+
+    // Validate all ARIA attributes
+    for (const attribute of ALL_ARIA_ATTRIBUTES) {
+      const value = element.getAttribute(attribute);
+
+      if (value === null) {
+        continue; // Attribute not present, no validation needed
+      }
+
+      // Skip aria-hidden as it's handled by AriaAttributes rule
+      if (attribute === "aria-hidden") {
+        continue;
+      }
+
+      // Validate attribute value
+      if (!validateAriaAttributeValue(attribute, value)) {
+        results.push({
+          type: "error",
+          message: "Invalid WAI-ARIA attribute value: {{attribute}}",
+          messageParams: { attribute },
+          ruleName,
+        });
+        continue; // Don't check role validity if value is already invalid
+      }
+
+      // Validate attribute is allowed for current role
+      if (!isValidAriaAttributeForRole(attribute, role)) {
+        results.push({
+          type: "error",
+          message: "Invalid role for WAI-ARIA attribute: {{attribute}}",
+          messageParams: { attribute },
+          ruleName,
+        });
+      }
+    }
+
+    return results.length > 0 ? results : undefined;
+  },
+};

--- a/apps/browser_extension/src/rules/type.ts
+++ b/apps/browser_extension/src/rules/type.ts
@@ -4,11 +4,13 @@ export type RuleResultError = {
   type: "error";
   ruleName: string;
   message: string;
+  messageParams?: Record<string, string>;
 };
 export type RuleResultWarning = {
   type: "warning";
   ruleName: string;
   message: string;
+  messageParams?: Record<string, string>;
 };
 export type RuleResultMessage = RuleResultError | RuleResultWarning;
 

--- a/apps/browser_extension/vite.test.config.ts
+++ b/apps/browser_extension/vite.test.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       enabled: true,
       provider: "playwright",
       headless: true,
-      screenshot: false,
+      screenshotFailures: false,
       instances: [
         {
           name: "chromium",


### PR DESCRIPTION
Formerly,there are limited error messages for invalid WAI-ARIA attributes which has invalid value or is attaced to invalid role, only for AriaState rule involves.
In this PR, all these invalid ARIA Attributes are shown, and show what attribute is invalid