### PR TITLE
Fix bug the element of Accessibiilty viusualizer will be duplicated on re-enabled

### DIFF
--- a/apps/browser_extension/entrypoints/content/index.ts
+++ b/apps/browser_extension/entrypoints/content/index.ts
@@ -3,7 +3,7 @@ export default defineContentScript({
   matches: ["<all_urls>"],
   main: async () => {
     const { injectRoot } = await import("./injectRoot");
-    
+
     // injectRootを一度だけ呼び出し、内部の状態管理に任せる
     injectRoot(window, window.document.body, { mountOnce: false });
   },


### PR DESCRIPTION
The bug is caused when a user re-enabled Accessibility Visualizer, a number of the element on `<body>` is increased 1 by 1 times.
It caused by the duplicated codes in the entry point of content script, and `injectRoot`. So the elements injected by script root and injectRoot when re-enabled.
In this PR, removed the one in the entry point

