### PR TITLE
showModal()ダイアログ表示中はモーダル外ライブリージョンを通知しない

### DIFF
--- a/apps/browser_extension/entrypoints/all-frames.content/hooks/useLiveRegionLocal.ts
+++ b/apps/browser_extension/entrypoints/all-frames.content/hooks/useLiveRegionLocal.ts
@@ -7,7 +7,7 @@ import { computeAccessibleName } from "dom-accessibility-api";
 import React from "react";
 import { collectShadowRoots } from "../../../src/dom/collectShadowRoots";
 import { SettingsContext } from "../../content/contexts/SettingsContext";
-import { detectModals } from "../../content/dom/detectModals";
+import { isAnnouncementSuppressedByModal } from "../../content/dom/detectModals";
 import { createLiveRegionMessage } from "../../content/shared/protocol";
 import type { AnnouncementItem, LiveLevel } from "../../content/types";
 
@@ -148,16 +148,15 @@ export const useLiveRegionLocal = ({
         return;
       }
 
-      if (!announceOutOfModal && parentRef.current) {
-        const modals = detectModals(parentRef.current);
-        if (modals.length > 0) {
-          const isInsideModal = modals.some(
-            (modal) => modal.contains(alertElement) || modal === alertElement,
-          );
-          if (!isInsideModal) {
-            return;
-          }
-        }
+      if (
+        parentRef.current &&
+        isAnnouncementSuppressedByModal(
+          alertElement,
+          parentRef.current,
+          announceOutOfModal,
+        )
+      ) {
+        return;
       }
 
       processedAlertsRef.current.add(alertElement);
@@ -276,17 +275,15 @@ export const useLiveRegionLocal = ({
             return null;
           }
 
-          if (!announceOutOfModal && parentRef.current) {
-            const modals = detectModals(parentRef.current);
-            if (modals.length > 0) {
-              const isInsideModal = modals.some(
-                (modal) =>
-                  modal.contains(targetElement) || modal === targetElement,
-              );
-              if (!isInsideModal) {
-                return null;
-              }
-            }
+          if (
+            parentRef.current &&
+            isAnnouncementSuppressedByModal(
+              targetElement,
+              parentRef.current,
+              announceOutOfModal,
+            )
+          ) {
+            return null;
           }
 
           const liveRegionNode = closestNodeOfSelector(

--- a/apps/browser_extension/entrypoints/content/dom/detectModals.test.ts
+++ b/apps/browser_extension/entrypoints/content/dom/detectModals.test.ts
@@ -1,5 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { detectModals, shouldHideBackgroundElements } from "./detectModals";
+import {
+  detectAriaModals,
+  detectModalDialogs,
+  detectModals,
+  isAnnouncementSuppressedByModal,
+  shouldHideBackgroundElements,
+} from "./detectModals";
+
+// showModal()はjsdomでは未実装のため、実ブラウザ環境でのみ実行する
+const supportsShowModal =
+  typeof HTMLDialogElement !== "undefined" &&
+  typeof HTMLDialogElement.prototype.showModal === "function";
 
 describe("detectModals", () => {
   let container: HTMLElement;
@@ -89,6 +100,202 @@ describe("detectModals", () => {
     const modals = detectModals(container);
     expect(modals).toHaveLength(1);
     expect(modals[0].id).toBe("nested-modal");
+  });
+});
+
+describe("detectAriaModals", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it("aria-modal='true'な要素を検出する", () => {
+    container.innerHTML = `
+      <div aria-modal="true" id="modal1">Modal 1</div>
+      <div aria-modal="false" id="not-modal">Not Modal</div>
+      <div id="no-aria">No Aria</div>
+    `;
+
+    const modals = detectAriaModals(container);
+    expect(modals).toHaveLength(1);
+    expect(modals[0].id).toBe("modal1");
+  });
+
+  it("非表示なaria-modal要素は除外する", () => {
+    container.innerHTML = `
+      <div aria-modal="true" id="hidden-modal" style="display: none;">Hidden</div>
+    `;
+
+    const modals = detectAriaModals(container);
+    expect(modals).toHaveLength(0);
+  });
+
+  it("aria-modalが存在しない場合は空配列を返す", () => {
+    container.innerHTML = `<div>Regular content</div>`;
+
+    const modals = detectAriaModals(container);
+    expect(modals).toHaveLength(0);
+  });
+});
+
+describe("detectModalDialogs", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it.runIf(supportsShowModal)("showModal()で開かれたdialogを検出する", () => {
+    const dialog = document.createElement("dialog");
+    dialog.id = "modal-dialog";
+    container.appendChild(dialog);
+    dialog.showModal();
+
+    const dialogs = detectModalDialogs(container);
+    expect(dialogs).toHaveLength(1);
+    expect(dialogs[0].id).toBe("modal-dialog");
+
+    dialog.close();
+  });
+
+  it.runIf(supportsShowModal)(
+    "show()で開かれた非モーダルなdialogは検出しない",
+    () => {
+      const dialog = document.createElement("dialog");
+      dialog.id = "non-modal-dialog";
+      container.appendChild(dialog);
+      dialog.show();
+
+      const dialogs = detectModalDialogs(container);
+      expect(dialogs).toHaveLength(0);
+
+      dialog.close();
+    },
+  );
+
+  it("open属性のみで開かれたdialogは検出しない", () => {
+    const dialog = document.createElement("dialog");
+    dialog.id = "open-dialog";
+    dialog.open = true;
+    container.appendChild(dialog);
+
+    const dialogs = detectModalDialogs(container);
+    expect(dialogs).toHaveLength(0);
+  });
+
+  it("閉じたdialogは検出しない", () => {
+    const dialog = document.createElement("dialog");
+    dialog.id = "closed-dialog";
+    container.appendChild(dialog);
+
+    const dialogs = detectModalDialogs(container);
+    expect(dialogs).toHaveLength(0);
+  });
+});
+
+describe("isAnnouncementSuppressedByModal", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it("モーダルが存在しない場合は抑制しない", () => {
+    container.innerHTML = `<div id="target">Live region</div>`;
+    const target = container.querySelector("#target") as Element;
+
+    expect(isAnnouncementSuppressedByModal(target, container, false)).toBe(
+      false,
+    );
+    expect(isAnnouncementSuppressedByModal(target, container, true)).toBe(
+      false,
+    );
+  });
+
+  describe("aria-modalが存在する場合", () => {
+    beforeEach(() => {
+      container.innerHTML = `
+        <div aria-modal="true" id="modal">
+          <span id="inside">Inside</span>
+        </div>
+        <div id="outside">Outside</div>
+      `;
+    });
+
+    it("announceOutOfModalがOFFのときモーダル外を抑制する", () => {
+      const inside = container.querySelector("#inside") as Element;
+      const outside = container.querySelector("#outside") as Element;
+
+      expect(isAnnouncementSuppressedByModal(outside, container, false)).toBe(
+        true,
+      );
+      expect(isAnnouncementSuppressedByModal(inside, container, false)).toBe(
+        false,
+      );
+    });
+
+    it("announceOutOfModalがONのときモーダル外も抑制しない", () => {
+      const outside = container.querySelector("#outside") as Element;
+
+      expect(isAnnouncementSuppressedByModal(outside, container, true)).toBe(
+        false,
+      );
+    });
+  });
+
+  it("open属性のみのdialog(非モーダル)はモーダル扱いせず抑制しない", () => {
+    container.innerHTML = `
+      <dialog id="dialog" open><span id="inside">Inside</span></dialog>
+      <div id="outside">Outside</div>
+    `;
+    const outside = container.querySelector("#outside") as Element;
+
+    // show()相当の非モーダルdialogは抑制対象外
+    expect(isAnnouncementSuppressedByModal(outside, container, false)).toBe(
+      false,
+    );
+  });
+
+  describe("showModal()のdialogが存在する場合", () => {
+    it.runIf(supportsShowModal)(
+      "announceOutOfModalがONでもモーダル外を抑制する",
+      () => {
+        const dialog = document.createElement("dialog");
+        dialog.innerHTML = `<span id="inside">Inside</span>`;
+        container.appendChild(dialog);
+        const outside = document.createElement("div");
+        outside.id = "outside";
+        container.appendChild(outside);
+        dialog.showModal();
+
+        const inside = dialog.querySelector("#inside") as Element;
+
+        expect(isAnnouncementSuppressedByModal(outside, container, true)).toBe(
+          true,
+        );
+        expect(isAnnouncementSuppressedByModal(inside, container, true)).toBe(
+          false,
+        );
+
+        dialog.close();
+      },
+    );
   });
 });
 

--- a/apps/browser_extension/entrypoints/content/dom/detectModals.ts
+++ b/apps/browser_extension/entrypoints/content/dom/detectModals.ts
@@ -1,18 +1,57 @@
 import { isHidden } from "@a11y-visualizer/dom-utils";
 
-export const detectModals = (root: Element | ShadowRoot): Element[] => {
-  // aria-modal="true"な要素を検出（ただし、アクセシビリティツリーにあるもののみ）
-  const ariaModalElements = Array.from(
-    root.querySelectorAll('[aria-modal="true"]'),
-  ).filter((element) => !isHidden(element));
+// aria-modal="true"な要素を検出（ただし、アクセシビリティツリーにあるもののみ）
+export const detectAriaModals = (root: Element | ShadowRoot): Element[] =>
+  Array.from(root.querySelectorAll('[aria-modal="true"]')).filter(
+    (element) => !isHidden(element),
+  );
 
-  // showModal()で開かれたdialog要素を検出
+// showModal()で開かれたdialog要素を検出（:modal疑似クラスにマッチするもの）
+// show()やopen属性のみで開かれた非モーダルなdialogは含まない
+export const detectModalDialogs = (root: Element | ShadowRoot): Element[] =>
+  Array.from(root.querySelectorAll("dialog")).filter((dialog) =>
+    dialog.matches(":modal"),
+  );
+
+export const detectModals = (root: Element | ShadowRoot): Element[] => {
+  const ariaModalElements = detectAriaModals(root);
+
+  // open状態のdialog要素を検出
   const openDialogElements = Array.from(root.querySelectorAll("dialog")).filter(
     (dialog) => (dialog as HTMLDialogElement).open,
   );
 
   // 重複を除去して結合
   return Array.from(new Set([...ariaModalElements, ...openDialogElements]));
+};
+
+// ライブリージョンの更新を通知すべきでないか（モーダルの外側にあるか）を判定する
+export const isAnnouncementSuppressedByModal = (
+  element: Element,
+  root: Element | ShadowRoot,
+  announceOutOfModal: boolean,
+): boolean => {
+  // showModal()で開かれたdialogは、それ以外をアクセシビリティツリーから除外するため、
+  // 設定に関わらずモーダル外のライブリージョンは通知しない
+  const modalDialogs = detectModalDialogs(root);
+  if (modalDialogs.length > 0) {
+    return !modalDialogs.some(
+      (dialog) => dialog.contains(element) || dialog === element,
+    );
+  }
+
+  // aria-modalはブラウザがアクセシビリティツリーから除外しないため、
+  // NVDA等の挙動シミュレーションとして、announceOutOfModalがOFFのときのみ外側を抑制する
+  if (!announceOutOfModal) {
+    const ariaModals = detectAriaModals(root);
+    if (ariaModals.length > 0) {
+      return !ariaModals.some(
+        (modal) => modal.contains(element) || modal === element,
+      );
+    }
+  }
+
+  return false;
 };
 
 export const shouldHideBackgroundElements = (root: Element): boolean => {


### PR DESCRIPTION
## 概要

「モーダル外のライブリージョンも通知」(`announceOutOfModal`) 設定について、`<dialog>` の `showModal()` で開かれた本物のモーダル表示中は、設定に関わらずモーダル外のライブリージョン更新を通知しないようにしました。

主要ブラウザでは `showModal()` 表示中、ダイアログ以外がアクセシビリティツリーから除外されるため、外側のライブリージョン更新は実際には決して通知されません。`announceOutOfModal` はあくまで `aria-modal` 等（NVDA挙動のシミュレーション）に対してのみ効力を持つべきです。

## 変更内容

- `detectModals.ts` に検出を細分化し、共通ヘルパーを追加
  - `detectAriaModals(root)`: `aria-modal="true"` かつ非表示でない要素
  - `detectModalDialogs(root)`: `showModal()` で開かれた `<dialog>`（`:modal` 疑似クラス）
  - `isAnnouncementSuppressedByModal(element, root, announceOutOfModal)`: 通知抑制判定の純粋関数
    - `showModal()` ダイアログがある → 設定に関わらずモーダル外を抑制
    - それ以外で `announceOutOfModal=false` → `aria-modal` 外を抑制（従来通り）
    - `show()` / `open` 属性のみの非モーダル `<dialog>` → 抑制しない
- `useLiveRegionLocal.ts` の2箇所に重複していたモーダル判定ロジックを共通ヘルパーに統一
- 視覚オーバーレイ側の `detectModals` / `shouldHideBackgroundElements` の挙動は変更なし

## テスト

- `detectModals.test.ts` に新関数のユニットテストを追加
  - `showModal()` 依存ケースは jsdom（未実装）では `it.runIf` でスキップ、実ブラウザ（Playwright chromium/firefox）でのみ実行
- `pnpm test`（実ブラウザ）/ `pnpm test:jsdom` / `pnpm compile` / `pnpm lint` すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)