### PR TITLE
Element.prototype.ariaNotify への対応

### DIFF
--- a/apps/browser_extension/entrypoints/aria-notify.content.ts
+++ b/apps/browser_extension/entrypoints/aria-notify.content.ts
@@ -1,41 +1,66 @@
+import { isHidden, isInAriaHidden } from "@a11y-visualizer/dom-utils";
 import { defineContentScript } from "#imports";
 
 const EVENT_NAME = "a11y-visualizer:aria-notify";
 const ENABLE_EVENT_NAME = "a11y-visualizer:aria-notify-patch-enable";
 const DISABLE_EVENT_NAME = "a11y-visualizer:aria-notify-patch-disable";
 
+type AriaNotifyOptions = { priority?: string };
+type AriaNotifyFn = (announcement: string, options?: AriaNotifyOptions) => void;
+
 export default defineContentScript({
   matches: ["<all_urls>"],
   allFrames: true,
   world: "MAIN",
   main: () => {
-    type AriaNotifyDocument = Document & {
-      ariaNotify?: (
-        announcement: string,
-        options?: { priority?: string },
-      ) => void;
-    };
+    type AriaNotifyDocument = Document & { ariaNotify?: AriaNotifyFn };
+    type AriaNotifyElementProto = Element & { ariaNotify?: AriaNotifyFn };
+
     const doc = document as AriaNotifyDocument;
-    const orig = doc.ariaNotify ? doc.ariaNotify.bind(doc) : null;
+    const origDocNotify = doc.ariaNotify ? doc.ariaNotify.bind(doc) : null;
+
+    const elementProto = Element.prototype as AriaNotifyElementProto;
+    const origElementNotify =
+      typeof elementProto.ariaNotify === "function"
+        ? elementProto.ariaNotify
+        : null;
+
     let patched = false;
+
+    const dispatch = (announcement: string, options?: AriaNotifyOptions) => {
+      document.dispatchEvent(
+        new CustomEvent(EVENT_NAME, {
+          detail: {
+            announcement: String(announcement),
+            priority: String(options?.priority || "none"),
+          },
+        }),
+      );
+    };
 
     const applyPatch = () => {
       if (patched) return;
       patched = true;
-      doc.ariaNotify = (
+
+      doc.ariaNotify = (announcement: string, options?: AriaNotifyOptions) => {
+        dispatch(announcement, options);
+        if (origDocNotify) {
+          return origDocNotify(announcement, options);
+        }
+      };
+
+      elementProto.ariaNotify = function (
+        this: Element,
         announcement: string,
-        options?: { priority?: string },
-      ) => {
-        document.dispatchEvent(
-          new CustomEvent(EVENT_NAME, {
-            detail: {
-              announcement: String(announcement),
-              priority: String(options?.priority || "none"),
-            },
-          }),
-        );
-        if (orig) {
-          return orig(announcement, options);
+        options?: AriaNotifyOptions,
+      ) {
+        // aria-liveなどのライブリージョンと同様に、アクセシビリティツリーから
+        // 除外されている要素では通知しない
+        if (!isHidden(this) && !isInAriaHidden(this)) {
+          dispatch(announcement, options);
+        }
+        if (origElementNotify) {
+          return origElementNotify.call(this, announcement, options);
         }
       };
     };
@@ -43,10 +68,17 @@ export default defineContentScript({
     const removePatch = () => {
       if (!patched) return;
       patched = false;
-      if (orig) {
-        doc.ariaNotify = orig;
+
+      if (origDocNotify) {
+        doc.ariaNotify = origDocNotify;
       } else {
         delete doc.ariaNotify;
+      }
+
+      if (origElementNotify) {
+        elementProto.ariaNotify = origElementNotify;
+      } else {
+        delete elementProto.ariaNotify;
       }
     };
 

--- a/apps/website/src/components/tests/LiveRegionTests.astro
+++ b/apps/website/src/components/tests/LiveRegionTests.astro
@@ -566,6 +566,35 @@ const t = createLocalT(lang === "ja" ? ja : en, en);
   </div>
 </ExampleCard>
 
+<ExampleCard
+  title={t("examples.ariaNotify.element.title")}
+  description={t("examples.ariaNotify.element.desc")}
+>
+  <div class="space-y-4">
+    <button
+      id="aria-notify-element-btn"
+      class="bg-teal-700 text-white px-4 py-2 rounded-sm hover:bg-teal-800 transition-colors"
+    >
+      Call element.ariaNotify
+    </button>
+  </div>
+</ExampleCard>
+
+<ExampleCard
+  title={t("examples.ariaNotify.hidden.title")}
+  description={t("examples.ariaNotify.hidden.desc")}
+>
+  <div class="space-y-4">
+    <button
+      id="aria-notify-hidden-btn"
+      class="bg-zinc-600 text-white px-4 py-2 rounded-sm hover:bg-zinc-700 transition-colors"
+    >
+      Call element.ariaNotify (excluded element)
+    </button>
+    <div id="aria-notify-hidden-target" aria-hidden="true" hidden></div>
+  </div>
+</ExampleCard>
+
 <CategorySectionTitle id="modal-live-regions"
   >{t("sections.modalLive.title")}</CategorySectionTitle
 >
@@ -1080,6 +1109,24 @@ const t = createLocalT(lang === "ja" ? ja : en, en);
         document.ariaNotify("Urgent notification via ariaNotify", {
           priority: "high",
         });
+      }
+    });
+
+  document
+    .getElementById("aria-notify-element-btn")
+    .addEventListener("click", (e) => {
+      const target = e.currentTarget;
+      if (typeof target.ariaNotify === "function") {
+        target.ariaNotify("Notification via element.ariaNotify");
+      }
+    });
+
+  document
+    .getElementById("aria-notify-hidden-btn")
+    .addEventListener("click", () => {
+      const target = document.getElementById("aria-notify-hidden-target");
+      if (target && typeof target.ariaNotify === "function") {
+        target.ariaNotify("This should NOT be announced (excluded element)");
       }
     });
 </script>

--- a/apps/website/src/components/tests/LiveRegionTests.lang.ts
+++ b/apps/website/src/components/tests/LiveRegionTests.lang.ts
@@ -92,6 +92,14 @@ export const en = {
         title: "ariaNotify (high priority)",
         desc: 'Calls document.ariaNotify() with priority "high". High-priority notifications may interrupt current speech output.',
       },
+      element: {
+        title: "element.ariaNotify()",
+        desc: "Calls ariaNotify() on a specific element. Element.prototype.ariaNotify() notifies assistive technologies in the context of that element.",
+      },
+      hidden: {
+        title: "element.ariaNotify() on an excluded element",
+        desc: "Calls ariaNotify() on an element that is excluded from the accessibility tree (display:none / aria-hidden). It should NOT be announced, just like live regions in hidden elements.",
+      },
     },
     modalLive: {
       dialog: {
@@ -199,6 +207,15 @@ export const ja = {
       high: {
         title: 'ariaNotify（priority: "high"）',
         desc: 'document.ariaNotify() を priority "high" で呼び出します。高優先度の通知は現在の読み上げを中断する可能性があります。',
+      },
+      element: {
+        title: "element.ariaNotify()",
+        desc: "特定の要素に対して ariaNotify() を呼び出します。Element.prototype.ariaNotify() はその要素の文脈で支援技術へ通知します。",
+      },
+      hidden: {
+        title:
+          "アクセシビリティツリーから除外された要素での element.ariaNotify()",
+        desc: "アクセシビリティツリーから除外された要素（display:none / aria-hidden）に対して ariaNotify() を呼び出します。隠れた要素内のライブリージョンと同様に、通知されないはずです。",
       },
     },
     modalLive: {


### PR DESCRIPTION
## 概要

`ariaNotify()` への対応を `document.ariaNotify()` だけでなく `Element.prototype.ariaNotify()` にも拡張しました。

## 変更内容

### `Element.prototype.ariaNotify` への対応
- `document.ariaNotify()` に加えて `Element.prototype.ariaNotify()` も「ariaNotifyをアナウンス（β）」の有効/無効に連動して書き換えるようにした
- パッチ無効時には元の実装を正しく復元（元々存在しない場合は `delete`）
- 通知ディスパッチ処理を `dispatch()` ヘルパーに共通化

### アクセシビリティツリーから除外された要素の扱い
- `Element.prototype.ariaNotify` では `this` 要素が `isHidden` / `isInAriaHidden` で除外されている場合、aria-live などのライブリージョンと同様にオーバーレイ通知を抑止する
- チェックは要素を直接参照できる MAIN world 内で実行
- ページ本来の動作を変えないよう、抑止する場合でも元の `ariaNotify` は `this` を保ったまま常に呼び出す

### テストページ
`LiveRegionTests` に以下の例を追加（en/ja 翻訳含む）:
- `element.ariaNotify()` の通常呼び出し
- 除外された要素（`display:none` / `aria-hidden`）での呼び出し（通知されないことを確認）

## 確認

- `pnpm --filter=@a11y-visualizer/browser-extension compile`: 通過
- `pnpm --filter=@a11y-visualizer/browser-extension test`: 430 tests passed
- `pnpm --filter=@a11y-visualizer/website build`: 成功
- `pnpm lint`: 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)