### PR TITLE
ci: PR/リリースのCIにbuildジョブを追加

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -70,3 +70,54 @@ jobs:
 
       - name: Run test
         run: pnpm test
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build for Chrome
+        run: pnpm build
+
+      - name: Build for Firefox
+        run: pnpm build:firefox
+
+  build_website:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build website
+        run: pnpm build:website

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,99 @@ jobs:
           context: test
           sha: ${{ needs.bump_version.outputs.SHA }}
 
+  build:
+    runs-on: ubuntu-latest
+    needs: bump_version
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump_version.outputs.SHA }}
+
+      - name: Set Commit Status Pending
+        uses: myrotvorets/set-commit-status-action@v2.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+          context: build
+          description: "Running build"
+          sha: ${{ needs.bump_version.outputs.SHA }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build for Chrome
+        run: pnpm build
+
+      - name: Build for Firefox
+        run: pnpm build:firefox
+
+      - name: Set Commit Status
+        uses: myrotvorets/set-commit-status-action@v2.0.1
+        if: ${{ always() }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          context: build
+          sha: ${{ needs.bump_version.outputs.SHA }}
+
+  build_website:
+    runs-on: ubuntu-latest
+    needs: bump_version
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump_version.outputs.SHA }}
+
+      - name: Set Commit Status Pending
+        uses: myrotvorets/set-commit-status-action@v2.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+          context: build_website
+          description: "Running website build"
+          sha: ${{ needs.bump_version.outputs.SHA }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build website
+        run: pnpm build:website
+
+      - name: Set Commit Status
+        uses: myrotvorets/set-commit-status-action@v2.0.1
+        if: ${{ always() }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          context: build_website
+          sha: ${{ needs.bump_version.outputs.SHA }}
+
   release:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## 概要

PR/main マージ時の CI (`pr_lint.yml`) は `lint` と `test` のみで、ビルドが通るか検証されていなかった。WXT/Vite ビルドや website ビルドの破壊を検出できるよう、build ジョブを追加する。

## 変更内容

### `.github/workflows/pr_lint.yml`
lint/test とは独立した2ジョブを追加:
- **`build`** … `pnpm build`（Chrome）+ `pnpm build:firefox`（Firefox）
- **`build_website`** … `pnpm build:website`

ChromeとFirefoxはWXTのターゲット違いだけで実質同一のため、同一ジョブ内で連続実行している。

### `.github/workflows/release.yml`
GitHub Actions が自動生成するリリースPRには Actions が起動しない制約があり、既存の `lint`/`test` 同様にコミットステータスを手動付与している。build を必須チェックにするなら release 側でも付与が必要なため、同等の2ジョブを追加:
- **`build`**（`context: build`）
- **`build_website`**（`context: build_website`）

`release` ジョブの `needs` は既存パターン通り `bump_version` のみで変更なし。

## 必須チェック名の整合性
pr_lint.yml のジョブ名と release.yml の `context:` 名を一致させている（`build` / `build_website`）。

## ⚠️ マージ後の運用作業
このPRをマージ後、ブランチ保護設定で **`build` / `build_website` を必須ステータスチェックに追加**する必要がある。

## 動作確認
- `pnpm build` / `pnpm build:firefox` / `pnpm build:website` をローカルで実行し、3ビルドとも成功を確認
- `pnpm lint-fix` 実行済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)