### PR TITLE
i18n: 「モーダル外」の文言を「aria-modal外」に具体化

### DIFF
--- a/apps/browser_extension/src/i18n/en.json
+++ b/apps/browser_extension/src/i18n/en.json
@@ -36,7 +36,7 @@
     "interactiveModeHideLabels": "Hide labels in interactive mode",
     "announceLiveRegions": "Announce live regions",
     "announceAriaNotify": "Announce ariaNotify (Beta)",
-    "announceOutOfModal": "Notify live regions outside modal",
+    "announceOutOfModal": "Notify live regions outside aria-modal",
     "announcement": "Announcement",
     "liveRegionDisplay": "Live region",
     "announcementSecondsPerCharacter": "speed (seconds/char)",

--- a/apps/browser_extension/src/i18n/ja.json
+++ b/apps/browser_extension/src/i18n/ja.json
@@ -36,7 +36,7 @@
     "interactiveModeHideLabels": "インタラクティブモードでラベルを隠す",
     "announceLiveRegions": "ライブリージョンをアナウンス",
     "announceAriaNotify": "ariaNotifyをアナウンス（β）",
-    "announceOutOfModal": "モーダル外のライブリージョンも通知",
+    "announceOutOfModal": "aria-modal外のライブリージョンも通知",
     "announcement": "アナウンス",
     "liveRegionDisplay": "ライブリージョン",
     "announcementSecondsPerCharacter": "スピード（秒/文字）",

--- a/apps/browser_extension/src/i18n/ko.json
+++ b/apps/browser_extension/src/i18n/ko.json
@@ -36,7 +36,7 @@
     "interactiveModeHideLabels": "인터랙티브 모드에서 라벨 숨기기",
     "announceLiveRegions": "라이브 리전을 안내",
     "announceAriaNotify": "ariaNotify 알림 (베타)",
-    "announceOutOfModal": "모달 외부 라이브 리전도 알림",
+    "announceOutOfModal": "aria-modal 외부 라이브 리전도 알림",
     "announcement": "안내",
     "liveRegionDisplay": "라이브 리전",
     "announcementSecondsPerCharacter": "속도(초/문자)",


### PR DESCRIPTION
## 概要

設定項目「モーダル外のライブリージョンも通知」の文言を「aria-modal外のライブリージョンも通知」に変更しました。

対象としているものが実質 `aria-modal` だけであるため、文言を具体的にしておきたいという意図です。

## 変更内容

設定キー（`announceOutOfModal`）や内部実装は変更せず、表示文言のみを更新しています。

| 言語 | Before | After |
| --- | --- | --- |
| ja | モーダル外のライブリージョンも通知 | aria-modal外のライブリージョンも通知 |
| en | Notify live regions outside modal | Notify live regions outside aria-modal |
| ko | 모달 외부 라이브 리전도 알림 | aria-modal 외부 라이브 리전도 알림 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)