### PR TITLE
inert属性・interactivity:inertスタイルへの対応を追加

### DIFF
--- a/apps/browser_extension/entrypoints/all-frames.content/hooks/useLiveRegionLocal.ts
+++ b/apps/browser_extension/entrypoints/all-frames.content/hooks/useLiveRegionLocal.ts
@@ -2,6 +2,7 @@ import {
   getKnownRole,
   isHidden,
   isInAriaHidden,
+  isInInert,
 } from "@a11y-visualizer/dom-utils";
 import { computeAccessibleName } from "dom-accessibility-api";
 import React from "react";
@@ -143,6 +144,7 @@ export const useLiveRegionLocal = ({
       if (
         isHidden(alertElement) ||
         isInAriaHidden(alertElement) ||
+        isInInert(alertElement) ||
         isBusy(alertElement)
       ) {
         return;
@@ -270,6 +272,7 @@ export const useLiveRegionLocal = ({
             !targetElement ||
             isHidden(targetElement) ||
             isInAriaHidden(targetElement) ||
+            isInInert(targetElement) ||
             isBusy(targetElement)
           ) {
             return null;

--- a/apps/browser_extension/entrypoints/aria-notify.content.ts
+++ b/apps/browser_extension/entrypoints/aria-notify.content.ts
@@ -1,4 +1,8 @@
-import { isHidden, isInAriaHidden } from "@a11y-visualizer/dom-utils";
+import {
+  isHidden,
+  isInAriaHidden,
+  isInInert,
+} from "@a11y-visualizer/dom-utils";
 import { defineContentScript } from "#imports";
 
 const EVENT_NAME = "a11y-visualizer:aria-notify";
@@ -56,7 +60,7 @@ export default defineContentScript({
       ) {
         // aria-liveなどのライブリージョンと同様に、アクセシビリティツリーから
         // 除外されている要素では通知しない
-        if (!isHidden(this) && !isInAriaHidden(this)) {
+        if (!isHidden(this) && !isInAriaHidden(this) && !isInInert(this)) {
           dispatch(announcement, options);
         }
         if (origElementNotify) {

--- a/apps/website/src/components/tests/InertTests.astro
+++ b/apps/website/src/components/tests/InertTests.astro
@@ -1,0 +1,175 @@
+---
+import { createLocalT } from "../../lib/i18n";
+import CategorySectionTitle from "./CategorySectionTitle.astro";
+import CategoryTitle from "./CategoryTitle.astro";
+import ExampleCard from "./ExampleCard.astro";
+import { en, ja } from "./InertTests.lang";
+
+interface Props {
+  lang?: string;
+}
+const lang = (Astro.props as Props).lang || "en";
+const t = createLocalT(lang === "ja" ? ja : en, en);
+---
+
+<CategoryTitle id="inert">{t("title")}</CategoryTitle>
+<p class="text-zinc-700 dark:text-zinc-300 mb-6">{t("intro")}</p>
+
+<CategorySectionTitle id="inert-interactive"
+  >{t("sections.interactive.title")}</CategorySectionTitle
+>
+
+<ExampleCard
+  title={t("examples.interactive.link.title")}
+  description={t("examples.interactive.link.desc")}
+>
+  <div
+    inert
+    class="border border-zinc-300 dark:border-zinc-600 rounded-sm p-3"
+  >
+    <a
+      href="https://github.com/ymrl/a11y-visualizer"
+      class="text-teal-700 dark:text-teal-400 underline"
+    >
+      Accessibility Visualizer
+    </a>
+  </div>
+</ExampleCard>
+
+<ExampleCard
+  title={t("examples.interactive.button.title")}
+  description={t("examples.interactive.button.desc")}
+>
+  <div
+    inert
+    class="border border-zinc-300 dark:border-zinc-600 rounded-sm p-3"
+  >
+    <button
+      type="button"
+      class="bg-teal-700 text-white px-4 py-2 rounded-sm hover:bg-teal-800 transition-colors"
+    >
+      {t("examples.interactive.button.button")}
+    </button>
+  </div>
+</ExampleCard>
+
+<ExampleCard
+  title={t("examples.interactive.form.title")}
+  description={t("examples.interactive.form.desc")}
+>
+  <form
+    inert
+    class="border border-zinc-300 dark:border-zinc-600 rounded-sm p-3 space-y-3"
+  >
+    <div class="flex flex-col gap-1">
+      <label for="inert-form-name" class="text-zinc-900 dark:text-zinc-100">
+        {t("examples.interactive.form.nameLabel")}
+      </label>
+      <input
+        id="inert-form-name"
+        type="text"
+        class="border border-zinc-300 dark:border-zinc-600 rounded-sm p-2 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100"
+      />
+    </div>
+    <div class="flex items-center gap-2">
+      <input id="inert-form-agree" type="checkbox" />
+      <label for="inert-form-agree" class="text-zinc-900 dark:text-zinc-100">
+        {t("examples.interactive.form.agreeLabel")}
+      </label>
+    </div>
+    <button
+      type="submit"
+      class="bg-teal-700 text-white px-4 py-2 rounded-sm hover:bg-teal-800 transition-colors"
+    >
+      {t("examples.interactive.form.submit")}
+    </button>
+  </form>
+</ExampleCard>
+
+<CategorySectionTitle id="inert-live-regions"
+  >{t("sections.liveRegions.title")}</CategorySectionTitle
+>
+
+<ExampleCard
+  title={t("examples.attribute.liveRegion.title")}
+  description={t("examples.attribute.liveRegion.desc")}
+>
+  <div class="space-y-4">
+    <div
+      inert
+      class="border border-zinc-300 dark:border-zinc-600 rounded-sm p-3 space-y-3"
+    >
+      <p class="text-sm text-zinc-700 dark:text-zinc-300">
+        {t("examples.attribute.liveRegion.label")}
+      </p>
+      <div
+        id="inert-attr-region"
+        aria-live="polite"
+        class="bg-blue-50 dark:bg-blue-900/20 p-3 rounded-sm border border-blue-200 dark:border-blue-700"
+      >
+        Ready
+      </div>
+    </div>
+    <button
+      class="bg-teal-700 text-white px-4 py-2 rounded-sm hover:bg-teal-800 transition-colors"
+      onclick="document.getElementById('inert-attr-region').textContent = 'Updated at ' + new Date().toLocaleTimeString()"
+    >
+      {t("examples.attribute.liveRegion.button")}
+    </button>
+  </div>
+</ExampleCard>
+
+<ExampleCard
+  title={t("examples.style.liveRegion.title")}
+  description={t("examples.style.liveRegion.desc")}
+>
+  <div class="space-y-4">
+    <div
+      style="interactivity: inert"
+      class="border border-zinc-300 dark:border-zinc-600 rounded-sm p-3 space-y-3"
+    >
+      <p class="text-sm text-zinc-700 dark:text-zinc-300">
+        {t("examples.style.liveRegion.label")}
+      </p>
+      <div
+        id="inert-style-region"
+        aria-live="polite"
+        class="bg-blue-50 dark:bg-blue-900/20 p-3 rounded-sm border border-blue-200 dark:border-blue-700"
+      >
+        Ready
+      </div>
+    </div>
+    <button
+      class="bg-teal-700 text-white px-4 py-2 rounded-sm hover:bg-teal-800 transition-colors"
+      onclick="document.getElementById('inert-style-region').textContent = 'Updated at ' + new Date().toLocaleTimeString()"
+    >
+      {t("examples.style.liveRegion.button")}
+    </button>
+  </div>
+</ExampleCard>
+
+<ExampleCard
+  title={t("examples.ariaNotify.element.title")}
+  description={t("examples.ariaNotify.element.desc")}
+>
+  <div class="space-y-4">
+    <button
+      id="inert-aria-notify-btn"
+      class="bg-teal-700 text-white px-4 py-2 rounded-sm hover:bg-teal-800 transition-colors"
+    >
+      {t("examples.ariaNotify.element.button")}
+    </button>
+    <div id="inert-aria-notify-target" inert></div>
+  </div>
+</ExampleCard>
+
+<script>
+  document
+    .getElementById("inert-aria-notify-btn")
+    ?.addEventListener("click", () => {
+      const target = document.getElementById("inert-aria-notify-target");
+      if (target && typeof (target as any).ariaNotify === "function") {
+        (target as any).ariaNotify("Notification from an inert element");
+      }
+    });
+</script>

--- a/apps/website/src/components/tests/InertTests.lang.ts
+++ b/apps/website/src/components/tests/InertTests.lang.ts
@@ -1,0 +1,105 @@
+export const en = {
+  title: "Inert",
+  intro:
+    "The inert attribute and the CSS interactivity: inert declaration make an element and its entire subtree non-interactive and remove them from the accessibility tree. Assistive technologies ignore content within an inert subtree.",
+  sections: {
+    interactive: { title: "Interactive Elements" },
+    liveRegions: { title: "Live Regions" },
+  },
+  examples: {
+    interactive: {
+      link: {
+        title: "Link inside an inert subtree",
+        desc: "A link placed inside a container with the inert attribute. It cannot receive focus or be activated, and it is removed from the accessibility tree.",
+      },
+      button: {
+        title: "Button inside an inert subtree",
+        desc: "A button placed inside a container with the inert attribute. It cannot be focused or clicked, and it is removed from the accessibility tree.",
+        button: "Inert Button",
+      },
+      form: {
+        title: "Form controls inside an inert subtree",
+        desc: "Form controls placed inside a container with the inert attribute. They cannot be focused or edited, and they are removed from the accessibility tree.",
+        nameLabel: "Name",
+        agreeLabel: "Agree to terms",
+        submit: "Submit",
+      },
+    },
+    attribute: {
+      liveRegion: {
+        title: "Live region inside an inert subtree",
+        desc: "A live region placed inside a container with the inert attribute. Because the subtree is removed from the accessibility tree, content changes are not conveyed to assistive technologies.",
+        button: "Update Live Region",
+        label: "Status (inert):",
+      },
+    },
+    style: {
+      liveRegion: {
+        title: "Live region inside an interactivity: inert subtree",
+        desc: "A live region inside a container styled with interactivity: inert. This CSS declaration expresses the same inert state as the attribute. Browser support for this property varies.",
+        button: "Update Live Region",
+        label: "Status (interactivity: inert):",
+      },
+    },
+    ariaNotify: {
+      element: {
+        title: "element.ariaNotify() on an inert element",
+        desc: "Calls ariaNotify() on an element that has the inert attribute. Notifications originating from an inert element are not conveyed to assistive technologies.",
+        button: "Call ariaNotify on inert element",
+      },
+    },
+  },
+} as const;
+
+export const ja = {
+  title: "Inert",
+  intro:
+    "inert 属性および CSS の interactivity: inert は、要素とそのサブツリー全体を操作不可にし、アクセシビリティツリーから除外します。inert なサブツリー内のコンテンツは支援技術から無視されます。",
+  sections: {
+    interactive: { title: "操作可能な要素" },
+    liveRegions: { title: "ライブリージョン" },
+  },
+  examples: {
+    interactive: {
+      link: {
+        title: "inert なサブツリー内のリンク",
+        desc: "inert 属性を持つコンテナ内に置かれたリンクです。フォーカスや操作ができず、アクセシビリティツリーからも除外されます。",
+      },
+      button: {
+        title: "inert なサブツリー内のボタン",
+        desc: "inert 属性を持つコンテナ内に置かれたボタンです。フォーカスやクリックができず、アクセシビリティツリーからも除外されます。",
+        button: "inert なボタン",
+      },
+      form: {
+        title: "inert なサブツリー内のフォームコントロール",
+        desc: "inert 属性を持つコンテナ内に置かれたフォームコントロールです。フォーカスや入力ができず、アクセシビリティツリーからも除外されます。",
+        nameLabel: "名前",
+        agreeLabel: "規約に同意する",
+        submit: "送信",
+      },
+    },
+    attribute: {
+      liveRegion: {
+        title: "inert なサブツリー内のライブリージョン",
+        desc: "inert 属性を持つコンテナ内に置かれたライブリージョンです。サブツリーがアクセシビリティツリーから除外されるため、内容の変化は支援技術に伝わりません。",
+        button: "ライブリージョンを更新",
+        label: "ステータス（inert）:",
+      },
+    },
+    style: {
+      liveRegion: {
+        title: "interactivity: inert なサブツリー内のライブリージョン",
+        desc: "interactivity: inert を指定したコンテナ内のライブリージョンです。この CSS 宣言は inert 属性と同等の状態を表します。このプロパティの対応状況はブラウザによって異なります。",
+        button: "ライブリージョンを更新",
+        label: "ステータス（interactivity: inert）:",
+      },
+    },
+    ariaNotify: {
+      element: {
+        title: "inert な要素での element.ariaNotify()",
+        desc: "inert 属性を持つ要素に対して ariaNotify() を呼び出します。inert な要素から発生した通知は支援技術に伝わりません。",
+        button: "inert な要素で ariaNotify を呼ぶ",
+      },
+    },
+  },
+} as const;

--- a/apps/website/src/lib/testCategories.ts
+++ b/apps/website/src/lib/testCategories.ts
@@ -9,6 +9,7 @@ export const testCategories = [
   { slug: "tables", dictKey: "tables" },
   { slug: "aria-hidden", dictKey: "ariaHidden" },
   { slug: "live-regions", dictKey: "liveRegions" },
+  { slug: "inert", dictKey: "inert" },
   { slug: "shadow-dom", dictKey: "shadowDom" },
 ] as const;
 

--- a/apps/website/src/pages/ja/tests.lang.ts
+++ b/apps/website/src/pages/ja/tests.lang.ts
@@ -25,6 +25,7 @@ const dict = {
       ariaHidden: "ARIA Hidden",
       landmarks: "レイアウトとランドマーク",
       liveRegions: "ライブリージョン",
+      inert: "Inert",
       shadowDom: "Shadow DOM",
     },
   },

--- a/apps/website/src/pages/ja/tests/[category].astro
+++ b/apps/website/src/pages/ja/tests/[category].astro
@@ -6,6 +6,7 @@ import ButtonTests from "../../../components/tests/ButtonTests.astro";
 import FormControlTests from "../../../components/tests/FormControlTests.astro";
 import HeadingTests from "../../../components/tests/HeadingTests.astro";
 import ImageTests from "../../../components/tests/ImageTests.astro";
+import InertTests from "../../../components/tests/InertTests.astro";
 import LayoutTests from "../../../components/tests/LayoutTests.astro";
 import LinkTests from "../../../components/tests/LinkTests.astro";
 import ListTests from "../../../components/tests/ListTests.astro";
@@ -63,5 +64,6 @@ const categoryName = t(`categories.headings.${dictKey}`);
   {category === "tables" && <TableTests lang="ja" />}
   {category === "aria-hidden" && <AriaHiddenTests lang="ja" />}
   {category === "live-regions" && <LiveRegionTests lang="ja" />}
+  {category === "inert" && <InertTests lang="ja" />}
   {category === "shadow-dom" && <ShadowDomTests lang="ja" />}
 </TestPageLayout>

--- a/apps/website/src/pages/tests.lang.ts
+++ b/apps/website/src/pages/tests.lang.ts
@@ -25,6 +25,7 @@ const dict = {
       ariaHidden: "ARIA Hidden",
       landmarks: "Layout & Landmarks",
       liveRegions: "Live Regions",
+      inert: "Inert",
       shadowDom: "Shadow DOM",
     },
   },

--- a/apps/website/src/pages/tests/[category].astro
+++ b/apps/website/src/pages/tests/[category].astro
@@ -6,6 +6,7 @@ import ButtonTests from "../../components/tests/ButtonTests.astro";
 import FormControlTests from "../../components/tests/FormControlTests.astro";
 import HeadingTests from "../../components/tests/HeadingTests.astro";
 import ImageTests from "../../components/tests/ImageTests.astro";
+import InertTests from "../../components/tests/InertTests.astro";
 import LayoutTests from "../../components/tests/LayoutTests.astro";
 import LinkTests from "../../components/tests/LinkTests.astro";
 import ListTests from "../../components/tests/ListTests.astro";
@@ -62,5 +63,6 @@ const categoryName = t(`categories.headings.${dictKey}`);
   {category === "tables" && <TableTests lang="en" />}
   {category === "aria-hidden" && <AriaHiddenTests lang="en" />}
   {category === "live-regions" && <LiveRegionTests lang="en" />}
+  {category === "inert" && <InertTests lang="en" />}
   {category === "shadow-dom" && <ShadowDomTests lang="en" />}
 </TestPageLayout>

--- a/packages/dom-utils/src/index.ts
+++ b/packages/dom-utils/src/index.ts
@@ -23,6 +23,7 @@ export { isAriaHidden, isInAriaHidden } from "./isAriaHidden";
 export { isDefaultSize } from "./isDefaultSize";
 export { FOCUSABLE_SELECTOR, isFocusable } from "./isFocusable";
 export { isHidden } from "./isHidden";
+export { isInert, isInInert } from "./isInert";
 export { isInline } from "./isInline";
 export { isPresentationalChildren } from "./isPresentationalChildren";
 export { type KnownRole, knownRoles } from "./KnownRole";

--- a/packages/dom-utils/src/isInert.test.ts
+++ b/packages/dom-utils/src/isInert.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { isInert, isInInert } from "./isInert";
+
+// CSSの interactivity: inert はブラウザ間で対応状況が異なる（Firefox未対応）。
+// 非対応ブラウザでは getComputedStyle が "inert" を返さないため、
+// 該当テストは test.skipIf でスキップする。属性ベースの挙動は全ブラウザで検証する。
+const supportsInteractivityInert =
+  typeof CSS !== "undefined" && !!CSS.supports?.("interactivity: inert");
+
+describe("isInert()", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("empty", () => {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    expect(isInert(element)).toBe(false);
+  });
+
+  test("inert attribute", () => {
+    const element = document.createElement("div");
+    element.setAttribute("inert", "");
+    document.body.appendChild(element);
+    expect(isInert(element)).toBe(true);
+  });
+
+  test.skipIf(!supportsInteractivityInert)("interactivity: inert style", () => {
+    const element = document.createElement("div");
+    element.style.setProperty("interactivity", "inert");
+    document.body.appendChild(element);
+    expect(isInert(element)).toBe(true);
+  });
+});
+
+describe("isInInert()", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("node is inert", () => {
+    const element = document.createElement("div");
+    element.setAttribute("inert", "");
+    document.body.appendChild(element);
+    expect(isInInert(element)).toBe(true);
+  });
+
+  test("parent is inert", () => {
+    const parent = document.createElement("div");
+    parent.setAttribute("inert", "");
+    const element = document.createElement("div");
+    parent.appendChild(element);
+    document.body.appendChild(parent);
+    expect(isInInert(element)).toBe(true);
+  });
+
+  test("grandparent is inert", () => {
+    const grandparent = document.createElement("div");
+    grandparent.setAttribute("inert", "");
+    const parent = document.createElement("div");
+    grandparent.appendChild(parent);
+    const element = document.createElement("div");
+    parent.appendChild(element);
+    document.body.appendChild(grandparent);
+    expect(isInInert(element)).toBe(true);
+  });
+
+  test("node is not inert", () => {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    expect(isInInert(element)).toBe(false);
+  });
+
+  test("parent is not inert", () => {
+    const parent = document.createElement("div");
+    const element = document.createElement("div");
+    parent.appendChild(element);
+    document.body.appendChild(parent);
+    expect(isInInert(element)).toBe(false);
+  });
+
+  test("grandparent is not inert", () => {
+    const grandparent = document.createElement("div");
+    const parent = document.createElement("div");
+    grandparent.appendChild(parent);
+    const element = document.createElement("div");
+    parent.appendChild(element);
+    document.body.appendChild(grandparent);
+    expect(isInInert(element)).toBe(false);
+  });
+
+  test.skipIf(!supportsInteractivityInert)(
+    "ancestor has interactivity: inert style",
+    () => {
+      const parent = document.createElement("div");
+      parent.style.setProperty("interactivity", "inert");
+      const element = document.createElement("div");
+      parent.appendChild(element);
+      document.body.appendChild(parent);
+      expect(isInInert(element)).toBe(true);
+    },
+  );
+});

--- a/packages/dom-utils/src/isInert.ts
+++ b/packages/dom-utils/src/isInert.ts
@@ -1,0 +1,28 @@
+export const isInert = (el: Element): boolean => {
+  if (el.hasAttribute("inert")) {
+    return true;
+  }
+  const w = el.ownerDocument.defaultView;
+  if (
+    w &&
+    w.getComputedStyle(el).getPropertyValue("interactivity") === "inert"
+  ) {
+    return true;
+  }
+  return false;
+};
+
+export const isInInert = (el: Element): boolean => {
+  if (isInert(el)) {
+    return true;
+  }
+  if (el.parentElement) {
+    return isInInert(el.parentElement);
+  }
+  // Shadow DOM境界を越えてhost要素を辿る（inertはshadow treeにも波及する）
+  const root = el.getRootNode();
+  if (root instanceof ShadowRoot) {
+    return isInInert(root.host);
+  }
+  return false;
+};


### PR DESCRIPTION
inert状態の要素はアクセシビリティツリーから除外されるため、その配下の
ライブリージョンやariaNotifyからの通知が行われないようにする。

- dom-utilsにisInert/isInInertを追加（inert属性またはinteractivity:inert スタイル、もしくは先祖がその状態かを判定）
- useLiveRegionLocal・aria-notify.contentの除外判定にisInInertを追加
- websiteにinertテストカテゴリを新設（操作可能な要素・ライブリージョンの例）