### PR TITLE
inertルールを追加

### DIFF
--- a/apps/browser_extension/src/i18n/en.json
+++ b/apps/browser_extension/src/i18n/en.json
@@ -126,6 +126,7 @@
   "Ungrouped radio button": "Ungrouped radio button",
   "Unknown role": "Unknown role",
   "May be skipped": "May be skipped",
+  "inert": "inert",
   "Small target": "Small target",
   "Heading level": "Heading level",
   "Page language": "Page language",

--- a/apps/browser_extension/src/i18n/ja.json
+++ b/apps/browser_extension/src/i18n/ja.json
@@ -126,6 +126,7 @@
   "Ungrouped radio button": "グループ化されていないラジオボタン",
   "Unknown role": "不明なロール",
   "May be skipped": "読み飛ばされる可能性あり",
+  "inert": "inert",
   "Small target": "ターゲットが小さい",
   "Heading level": "見出しレベル",
   "Page language": "ページの言語",

--- a/apps/browser_extension/src/i18n/ko.json
+++ b/apps/browser_extension/src/i18n/ko.json
@@ -126,6 +126,7 @@
   "Ungrouped radio button": "라디오 버튼 그룹 없음",
   "Unknown role": "Unknown role",
   "May be skipped": "May be skipped",
+  "inert": "inert",
   "Small target": "Small target",
   "Heading level": "헤딩 레벨",
   "Page language": "Page language",

--- a/packages/rules/src/Rules.ts
+++ b/packages/rules/src/Rules.ts
@@ -14,6 +14,7 @@ import { Hgroup } from "./hgroup";
 import { IdReference } from "./id-reference";
 import { IframeName } from "./iframe-name";
 import { ImageName } from "./image-name";
+import { Inert } from "./inert";
 import { LabelAssociatedControl } from "./label-associated-control";
 import { Landmark } from "./landmark";
 import { Lang } from "./lang";
@@ -68,4 +69,5 @@ export const Rules = [
   AbstractRole,
   AriaAttributes,
   TabIndex,
+  Inert,
 ] as const;

--- a/packages/rules/src/inert/index.test.ts
+++ b/packages/rules/src/inert/index.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { Inert } from ".";
+
+// CSSの interactivity: inert はブラウザ間で対応状況が異なる（Firefox未対応）。
+// 非対応ブラウザでは getComputedStyle が "inert" を返さないため、
+// 該当テストは test.skipIf でスキップする。属性ベースの挙動は全ブラウザで検証する。
+const supportsInteractivityInert =
+  typeof CSS !== "undefined" && !!CSS.supports?.("interactivity: inert");
+
+const warningResult = [
+  {
+    type: "warning",
+    ruleName: "inert",
+    message: "inert",
+  },
+];
+
+describe("inert", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("no inert", () => {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    const result = Inert.evaluate(element, { enabled: true }, {});
+    expect(result).toBeUndefined();
+  });
+
+  test("inert attribute on the element itself", () => {
+    const element = document.createElement("div");
+    element.setAttribute("inert", "");
+    document.body.appendChild(element);
+    const result = Inert.evaluate(element, { enabled: true }, {});
+    expect(result).toEqual(warningResult);
+  });
+
+  test("inert attribute on an ancestor", () => {
+    const ancestor = document.createElement("div");
+    ancestor.setAttribute("inert", "");
+    const element = document.createElement("div");
+    ancestor.appendChild(element);
+    document.body.appendChild(ancestor);
+    const result = Inert.evaluate(element, { enabled: true }, {});
+    expect(result).toEqual(warningResult);
+  });
+
+  test("disabled", () => {
+    const element = document.createElement("div");
+    element.setAttribute("inert", "");
+    document.body.appendChild(element);
+    const result = Inert.evaluate(element, { enabled: false }, {});
+    expect(result).toBeUndefined();
+  });
+
+  test.skipIf(!supportsInteractivityInert)("interactivity: inert style", () => {
+    const element = document.createElement("div");
+    element.style.setProperty("interactivity", "inert");
+    document.body.appendChild(element);
+    const result = Inert.evaluate(element, { enabled: true }, {});
+    expect(result).toEqual(warningResult);
+  });
+});

--- a/packages/rules/src/inert/index.ts
+++ b/packages/rules/src/inert/index.ts
@@ -1,0 +1,27 @@
+import { isInInert } from "@a11y-visualizer/dom-utils";
+import type { RuleObject } from "../type";
+
+const ruleName = "inert";
+const defaultOptions = {
+  enabled: true,
+};
+
+export const Inert: RuleObject = {
+  ruleName,
+  defaultOptions,
+  evaluate: (element, { enabled } = defaultOptions) => {
+    if (!enabled) {
+      return undefined;
+    }
+    if (isInInert(element)) {
+      return [
+        {
+          type: "warning",
+          message: "inert",
+          ruleName,
+        },
+      ];
+    }
+    return undefined;
+  },
+};


### PR DESCRIPTION
## 概要

要素自身またはその先祖に `inert` 属性、もしくは CSS の `interactivity: inert` が指定されている場合に warning「inert」を表示するルールを追加しました。

inert な要素はユーザー操作・支援技術から不活性扱いになりますが、見落としやすいため、対象要素に気づけるようにします。

## 変更内容

- **新規ルール** `packages/rules/src/inert/index.ts`
  - 全要素を対象とし、`@a11y-visualizer/dom-utils` の `isInInert`（要素自身・先祖・Shadow DOM 境界を辿る）が true なら warning「inert」を返す
- **テスト** `packages/rules/src/inert/index.test.ts`
  - inert なし / 自身に inert 属性 / 先祖に inert 属性 / disabled / `interactivity: inert` スタイル（非対応環境は skip）
- **登録** `packages/rules/src/Rules.ts` の `Rules` 配列に追加
- **i18n** en/ja/ko すべてに `"inert": "inert"` を追加（表示はすべて「inert」）

## 確認

- `pnpm --filter=@a11y-visualizer/rules test src/inert/index.test.ts` → 9 passed / 1 skipped
- `pnpm --filter=@a11y-visualizer/browser-extension compile` → 型エラーなし
- `pnpm lint-fix` → 問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)