### PR TITLE
fix: テストページのモーダルダイアログのTailwind v4対応

### DIFF
--- a/apps/website/src/components/tests/LayoutTests.astro
+++ b/apps/website/src/components/tests/LayoutTests.astro
@@ -210,7 +210,7 @@ const t = createLocalT(lang === "ja" ? ja : en, en);
 
     <dialog
       id="example-dialog"
-      class="p-6 rounded-lg shadow-lg backdrop:bg-black backdrop:bg-opacity-50"
+      class="m-auto p-6 rounded-lg shadow-lg backdrop:bg-black/50"
     >
       <div class="space-y-4">
         <h3 class="text-lg font-bold text-zinc-700 dark:text-zinc-300">
@@ -240,7 +240,7 @@ const t = createLocalT(lang === "ja" ? ja : en, en);
     role="dialog"
     aria-modal="true"
     aria-labelledby="modal-title"
-    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden"
+    class="fixed inset-0 bg-black/50 flex items-center justify-center hidden"
     id="custom-modal"
   >
     <div

--- a/apps/website/src/components/tests/LiveRegionTests.astro
+++ b/apps/website/src/components/tests/LiveRegionTests.astro
@@ -622,7 +622,7 @@ const t = createLocalT(lang === "ja" ? ja : en, en);
     <dialog
       id="modal-live-dialog"
       aria-labelledby="modal-live-dialog-title"
-      class="p-6 rounded-lg shadow-lg backdrop:bg-black backdrop:bg-opacity-50"
+      class="m-auto p-6 rounded-lg shadow-lg backdrop:bg-black/50"
     >
       <div class="space-y-4">
         <h3
@@ -687,7 +687,7 @@ const t = createLocalT(lang === "ja" ? ja : en, en);
       role="dialog"
       aria-modal="true"
       aria-labelledby="live-modal-title"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center hidden"
       id="live-custom-modal"
     >
       <div


### PR DESCRIPTION
## 概要

`apps/website` のテストページにあるモーダルダイアログのスタイルが、Tailwind を v4 にしたことで壊れていた問題を修正します。

## 症状

- `<dialog>` 要素を使ったモーダル: 画面中央に表示されるべきが**画面左上**に表示され、backdrop が半透明であるべきが**不透明**になっていた
- `aria-modal="true"` を使ったカスタムダイアログ: backdrop が半透明であるべきが**不透明**になっていた

## 原因

1. **backdrop が不透明になる問題**
   `bg-opacity-50` / `backdrop:bg-opacity-50` ユーティリティは Tailwind v4 で廃止され、スラッシュ記法 `bg-black/50` に置き換えられた。そのため `bg-black` だけが効いて完全な不透明になっていた。

2. **`<dialog>` が画面左上に表示される問題**
   Tailwind v4 の preflight が全称セレクタ `*` に対して `margin: 0` を適用するようになった（v3 では特定要素のみ）。これにより `<dialog>` も対象となり、ブラウザ標準スタイルのモーダルダイアログ中央寄せ（`margin: auto`）が打ち消されていた。

## 修正内容

`LayoutTests.astro` / `LiveRegionTests.astro` のモーダルダイアログ箇所（計4箇所）を修正:

- `<dialog>` 要素: `backdrop:bg-black backdrop:bg-opacity-50` → `m-auto ... backdrop:bg-black/50`
- `aria-modal="true"` カスタムダイアログ: `bg-black bg-opacity-50` → `bg-black/50`

🤖 Generated with [Claude Code](https://claude.com/claude-code)