### PR TITLE
fix: 行グループ・列グループヘッダーの割り当てを仕様に合わせて修正

### DIFF
--- a/apps/website/src/components/tests/TableTests.astro
+++ b/apps/website/src/components/tests/TableTests.astro
@@ -15,6 +15,8 @@ const tableClasses =
   "border-collapse border border-zinc-300 dark:border-zinc-600";
 const cellClasses =
   "border border-zinc-300 dark:border-zinc-600 p-2 text-zinc-900 dark:text-zinc-100";
+const colHeaderClasses = `${cellClasses} bg-zinc-100 dark:bg-zinc-700 font-bold`;
+const rowHeaderClasses = `${cellClasses} bg-zinc-50 dark:bg-zinc-800 font-bold`;
 ---
 
 <CategoryTitle id="tables">{t("title")}</CategoryTitle>
@@ -163,6 +165,126 @@ const cellClasses =
       <tr>
         <td class={cellClasses}>Bob</td>
         <td class={cellClasses}>Marketing</td>
+      </tr>
+    </tbody>
+  </table>
+</ExampleCard>
+
+<CategorySectionTitle id="table-complex"
+  >{t("sections.complex.title")}</CategorySectionTitle
+>
+
+<ExampleCard
+  title={t("examples.complex.rowGroupHeaders.title")}
+  description={t("examples.complex.rowGroupHeaders.desc")}
+>
+  <table class={tableClasses}>
+    <thead>
+      <tr>
+        <th scope="col" class={colHeaderClasses}>ID</th>
+        <th scope="col" class={colHeaderClasses}>Measurement</th>
+        <th scope="col" class={colHeaderClasses}>Average</th>
+        <th scope="col" class={colHeaderClasses}>Maximum</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class={cellClasses}></td>
+        <th scope="rowgroup" class={rowHeaderClasses}>Cats</th>
+        <td class={cellClasses}></td>
+        <td class={cellClasses}></td>
+      </tr>
+      <tr>
+        <td class={cellClasses}>93</td>
+        <th scope="row" class={rowHeaderClasses}>Legs</th>
+        <td class={cellClasses}>3.5</td>
+        <td class={cellClasses}>4</td>
+      </tr>
+      <tr>
+        <td class={cellClasses}>10</td>
+        <th scope="row" class={rowHeaderClasses}>Tails</th>
+        <td class={cellClasses}>1</td>
+        <td class={cellClasses}>1</td>
+      </tr>
+    </tbody>
+    <tbody>
+      <tr>
+        <td class={cellClasses}></td>
+        <th scope="rowgroup" class={rowHeaderClasses}>English speakers</th>
+        <td class={cellClasses}></td>
+        <td class={cellClasses}></td>
+      </tr>
+      <tr>
+        <td class={cellClasses}>32</td>
+        <th scope="row" class={rowHeaderClasses}>Legs</th>
+        <td class={cellClasses}>2.67</td>
+        <td class={cellClasses}>4</td>
+      </tr>
+      <tr>
+        <td class={cellClasses}>35</td>
+        <th scope="row" class={rowHeaderClasses}>Tails</th>
+        <td class={cellClasses}>0.33</td>
+        <td class={cellClasses}>1</td>
+      </tr>
+    </tbody>
+  </table>
+</ExampleCard>
+
+<ExampleCard
+  title={t("examples.complex.colGroupHeaders.title")}
+  description={t("examples.complex.colGroupHeaders.desc")}
+>
+  <table class={tableClasses}>
+    <colgroup></colgroup>
+    <colgroup span="2"></colgroup>
+    <thead>
+      <tr>
+        <td class={cellClasses}></td>
+        <th scope="colgroup" colspan="2" class={colHeaderClasses}>Sales</th>
+      </tr>
+      <tr>
+        <th scope="col" class={colHeaderClasses}>Month</th>
+        <th scope="col" class={colHeaderClasses}>Online</th>
+        <th scope="col" class={colHeaderClasses}>Store</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row" class={rowHeaderClasses}>January</th>
+        <td class={cellClasses}>120</td>
+        <td class={cellClasses}>340</td>
+      </tr>
+      <tr>
+        <th scope="row" class={rowHeaderClasses}>February</th>
+        <td class={cellClasses}>150</td>
+        <td class={cellClasses}>310</td>
+      </tr>
+    </tbody>
+  </table>
+</ExampleCard>
+
+<ExampleCard
+  title={t("examples.complex.rowHeaderNotFirst.title")}
+  description={t("examples.complex.rowHeaderNotFirst.desc")}
+>
+  <table class={tableClasses}>
+    <thead>
+      <tr>
+        <th scope="col" class={colHeaderClasses}>Rank</th>
+        <th scope="col" class={colHeaderClasses}>Country</th>
+        <th scope="col" class={colHeaderClasses}>Capital</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class={cellClasses}>1</td>
+        <th scope="row" class={rowHeaderClasses}>Japan</th>
+        <td class={cellClasses}>Tokyo</td>
+      </tr>
+      <tr>
+        <td class={cellClasses}>2</td>
+        <th scope="row" class={rowHeaderClasses}>France</th>
+        <td class={cellClasses}>Paris</td>
       </tr>
     </tbody>
   </table>

--- a/apps/website/src/components/tests/TableTests.astro
+++ b/apps/website/src/components/tests/TableTests.astro
@@ -228,6 +228,10 @@ const rowHeaderClasses = `${cellClasses} bg-zinc-50 dark:bg-zinc-800 font-bold`;
       </tr>
     </tbody>
   </table>
+  <p
+    class="text-xs text-zinc-500 dark:text-zinc-400 mt-3"
+    set:html={t("examples.complex.rowGroupHeaders.credit")}
+  />
 </ExampleCard>
 
 <ExampleCard

--- a/apps/website/src/components/tests/TableTests.lang.ts
+++ b/apps/website/src/components/tests/TableTests.lang.ts
@@ -32,6 +32,8 @@ export const en = {
       rowGroupHeaders: {
         title: 'Row group headers (scope="rowgroup")',
         desc: '✅ scope="rowgroup" headers (Cats, English speakers) apply to every cell in their row group except cells in the columns to their left. Note that the row headers (Legs, Tails) are placed in the second column, not the leftmost one.',
+        credit:
+          'This table is from the <a href="https://html.spec.whatwg.org/multipage/tables.html" class="underline" target="_blank" rel="noopener noreferrer">HTML Standard</a> by WHATWG, used under <a href="https://creativecommons.org/licenses/by/4.0/" class="underline" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>.',
       },
       colGroupHeaders: {
         title: 'Column group headers (scope="colgroup")',
@@ -79,6 +81,8 @@ export const ja = {
       rowGroupHeaders: {
         title: '行グループの見出し（scope="rowgroup"）',
         desc: '✅ scope="rowgroup" の見出し（Cats、English speakers）は、その行グループ内で自分より左の列を除くすべてのセルに適用されます。行見出し（Legs、Tails）が左端ではなく2列目に置かれている点にも注目してください。',
+        credit:
+          'この表は WHATWG による <a href="https://html.spec.whatwg.org/multipage/tables.html" class="underline" target="_blank" rel="noopener noreferrer">HTML Standard</a> から引用したもので、<a href="https://creativecommons.org/licenses/by/4.0/" class="underline" target="_blank" rel="noopener noreferrer">CC BY 4.0</a> のもとで利用しています。',
       },
       colGroupHeaders: {
         title: '列グループの見出し（scope="colgroup"）',

--- a/apps/website/src/components/tests/TableTests.lang.ts
+++ b/apps/website/src/components/tests/TableTests.lang.ts
@@ -5,6 +5,7 @@ export const en = {
   sections: {
     structure: { title: "Table Structure" },
     headers: { title: "Table Headers" },
+    complex: { title: "Complex Headers" },
   },
   examples: {
     structure: {
@@ -27,6 +28,20 @@ export const en = {
         desc: "✅ Table with caption element providing context about the table's purpose. Helps users understand what data the table contains.",
       },
     },
+    complex: {
+      rowGroupHeaders: {
+        title: 'Row group headers (scope="rowgroup")',
+        desc: '✅ scope="rowgroup" headers (Cats, English speakers) apply to every cell in their row group except cells in the columns to their left. Note that the row headers (Legs, Tails) are placed in the second column, not the leftmost one.',
+      },
+      colGroupHeaders: {
+        title: 'Column group headers (scope="colgroup")',
+        desc: '✅ A scope="colgroup" header (Sales) applies to every cell in its column group, grouping multiple columns under a shared heading.',
+      },
+      rowHeaderNotFirst: {
+        title: "Row header not in the first column",
+        desc: '✅ The row header (Country) is in the second column with a data column (Rank) to its left. scope="row" headers apply only to cells on their right, so the Rank column is not associated with them.',
+      },
+    },
   },
 } as const;
 
@@ -37,6 +52,7 @@ export const ja = {
   sections: {
     structure: { title: "テーブルの構造" },
     headers: { title: "ヘッダー" },
+    complex: { title: "複雑なヘッダー" },
   },
   examples: {
     structure: {
@@ -57,6 +73,20 @@ export const ja = {
       withCaption: {
         title: "caption のあるテーブル",
         desc: "✅ caption 要素によりテーブルの目的や内容の文脈を提供します。利用者が理解しやすくなります。",
+      },
+    },
+    complex: {
+      rowGroupHeaders: {
+        title: '行グループの見出し（scope="rowgroup"）',
+        desc: '✅ scope="rowgroup" の見出し（Cats、English speakers）は、その行グループ内で自分より左の列を除くすべてのセルに適用されます。行見出し（Legs、Tails）が左端ではなく2列目に置かれている点にも注目してください。',
+      },
+      colGroupHeaders: {
+        title: '列グループの見出し（scope="colgroup"）',
+        desc: '✅ scope="colgroup" の見出し（Sales）は、その列グループ内のすべてのセルに適用され、複数の列を共通の見出しでまとめます。',
+      },
+      rowHeaderNotFirst: {
+        title: "左端の列にない行見出し",
+        desc: '✅ 行見出し（Country）が2列目にあり、その左にデータ列（Rank）があります。scope="row" の見出しは右側のセルにのみ適用されるため、Rank 列とは関連付けられません。',
       },
     },
   },

--- a/packages/table/src/index.test.ts
+++ b/packages/table/src/index.test.ts
@@ -607,6 +607,101 @@ describe("Table", () => {
       expect(headers_5_1.find((c) => c.id === "cell-0-1")).toBeDefined();
       expect(headers_5_1).toHaveLength(1);
     });
+
+    test("rowgroup header is excluded from cells to its left (WHATWG example)", () => {
+      // https://html.spec.whatwg.org/multipage/tables.html
+      // 行グループヘッダー(scope=rowgroup)は、自分より左の列(最初のID列)には適用されない
+      const table = document.createElement("table");
+      table.innerHTML = `
+        <thead>
+          <tr> <th id="h-id">ID</th> <th id="h-meas">Measurement</th> <th id="h-avg">Average</th> <th id="h-max">Maximum</th> </tr>
+        </thead>
+        <tbody>
+          <tr> <td id="c-cats-id"></td> <th id="h-cats" scope="rowgroup">Cats</th> <td></td> <td></td> </tr>
+          <tr> <td id="c-93">93</td> <th id="h-legs1" scope="row">Legs</th> <td id="c-35">3.5</td> <td id="c-4">4</td> </tr>
+          <tr> <td id="c-10">10</td> <th id="h-tails1" scope="row">Tails</th> <td id="c-1a">1</td> <td id="c-1b">1</td> </tr>
+        </tbody>
+        <tbody>
+          <tr> <td id="c-eng-id"></td> <th id="h-eng" scope="rowgroup">English speakers</th> <td></td> <td></td> </tr>
+          <tr> <td id="c-32">32</td> <th id="h-legs2" scope="row">Legs</th> <td id="c-267">2.67</td> <td id="c-4b">4</td> </tr>
+          <tr> <td id="c-35b">35</td> <th id="h-tails2" scope="row">Tails</th> <td id="c-033">0.33</td> <td id="c-1c">1</td> </tr>
+        </tbody>
+      `;
+      const result = new Table(table);
+      const byId = (id: string) =>
+        result.getCell(table.querySelector(`#${id}`) as Element) as NonNullable<
+          ReturnType<typeof result.getCell>
+        >;
+
+      // ID列(x=0)のセルには rowgroup ヘッダー "Cats" は適用されない。
+      // 行ヘッダー "Legs"(x=1, scope=row) も右方向にしか効かないので適用されず、列ヘッダー "ID" のみ。
+      const headers93 = result.getHeaderElements(byId("c-93")).map((e) => e.id);
+      expect(headers93).not.toContain("h-cats");
+      expect(headers93).not.toContain("h-legs1");
+      expect(headers93).toContain("h-id");
+      expect(headers93).toHaveLength(1);
+
+      // Average列(x=2)のセルには "Cats" が適用される
+      const headers35 = result.getHeaderElements(byId("c-35")).map((e) => e.id);
+      expect(headers35).toContain("h-cats");
+      expect(headers35).toContain("h-avg");
+      expect(headers35).toContain("h-legs1");
+      expect(headers35).toHaveLength(3);
+
+      // 2つ目の行グループのヘッダー "English speakers" は1つ目の行グループのセルには適用されない
+      expect(headers35).not.toContain("h-eng");
+      const headers267 = result
+        .getHeaderElements(byId("c-267"))
+        .map((e) => e.id);
+      expect(headers267).toContain("h-eng");
+      expect(headers267).not.toContain("h-cats");
+    });
+
+    test("colgroup header is excluded from cells to its left", () => {
+      // 列グループヘッダー(scope=colgroup)も、自分より左の列には適用されない
+      const table = document.createElement("table");
+      table.innerHTML = `
+        <colgroup span="1"></colgroup>
+        <colgroup span="3"></colgroup>
+        <thead>
+          <tr>
+            <th id="h-0-0">0-0</th>
+            <td id="c-0-1"></td>
+            <th id="h-0-2" scope="colgroup">grp</th>
+            <td id="c-0-3"></td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td id="c-1-0">1-0</td>
+            <td id="c-1-1">1-1</td>
+            <td id="c-1-2">1-2</td>
+            <td id="c-1-3">1-3</td>
+          </tr>
+        </tbody>
+      `;
+      const result = new Table(table);
+      const byId = (id: string) =>
+        result.getCell(table.querySelector(`#${id}`) as Element) as NonNullable<
+          ReturnType<typeof result.getCell>
+        >;
+
+      // x=1 のセルは colgroup ヘッダー(x=2)より左なので適用されない
+      const headers11 = result
+        .getHeaderElements(byId("c-1-1"))
+        .map((e) => e.id);
+      expect(headers11).not.toContain("h-0-2");
+
+      // x=2 / x=3 のセルには colgroup ヘッダーが適用される
+      const headers12 = result
+        .getHeaderElements(byId("c-1-2"))
+        .map((e) => e.id);
+      expect(headers12).toContain("h-0-2");
+      const headers13 = result
+        .getHeaderElements(byId("c-1-3"))
+        .map((e) => e.id);
+      expect(headers13).toContain("h-0-2");
+    });
   });
 });
 

--- a/packages/table/src/index.test.ts
+++ b/packages/table/src/index.test.ts
@@ -609,7 +609,10 @@ describe("Table", () => {
     });
 
     test("rowgroup header is excluded from cells to its left (WHATWG example)", () => {
+      // この表は WHATWG による HTML Standard から引用したもので、CC BY 4.0 のもとで利用している
+      // This table is from the HTML Standard by WHATWG, used under CC BY 4.0.
       // https://html.spec.whatwg.org/multipage/tables.html
+      // https://creativecommons.org/licenses/by/4.0/
       // 行グループヘッダー(scope=rowgroup)は、自分より左の列(最初のID列)には適用されない
       const table = document.createElement("table");
       table.innerHTML = `

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -326,7 +326,7 @@ export class Table {
   };
 
   getRowGroupHeaderElements = (cell: Cell): Element[] => {
-    const { positionY, element } = cell;
+    const { positionY, positionX, sizeX, sizeY, element } = cell;
     const rowGroup = this.rowGroups.find(
       (group) =>
         group.positionY <= positionY &&
@@ -338,8 +338,12 @@ export class Table {
         row.filter(
           (c) =>
             c.headerScope === "rowgroup" &&
+            // 同じ行グループに属するヘッダー
             c.positionY < rowGroup.positionY + rowGroup.sizeY &&
-            c.positionY + c.sizeY > rowGroup.positionY,
+            c.positionY + c.sizeY > rowGroup.positionY &&
+            // 仕様の座標制約: ヘッダーは対象セルの右端・下端より右下にはみ出さない
+            c.positionX <= positionX + sizeX - 1 &&
+            c.positionY <= positionY + sizeY - 1,
         ),
       )
       .map((c) => c.element)
@@ -388,7 +392,7 @@ export class Table {
   };
 
   getColGroupHeaderElements = (cell: Cell): Element[] => {
-    const { positionY, positionX, element } = cell;
+    const { positionY, positionX, sizeX, sizeY, element } = cell;
     const colGroup = this.colGroups.find(
       (group) =>
         group.positionX <= positionX &&
@@ -399,10 +403,13 @@ export class Table {
       .flatMap((row) =>
         row.filter(
           (c) =>
-            c.positionY < positionY &&
             c.headerScope === "colgroup" &&
+            // 同じ列グループに属するヘッダー
             c.positionX < colGroup.positionX + colGroup.sizeX &&
-            c.positionX + c.sizeX > colGroup.positionX,
+            c.positionX + c.sizeX > colGroup.positionX &&
+            // 仕様の座標制約: ヘッダーは対象セルの右端・下端より右下にはみ出さない
+            c.positionX <= positionX + sizeX - 1 &&
+            c.positionY <= positionY + sizeY - 1,
         ),
       )
       .map((c) => c.element)


### PR DESCRIPTION
## 概要

`packages/table` における scope=rowgroup / colgroup ヘッダーの割り当てが HTML 仕様（[WHATWG HTML 4.9.12.2 Forming relationships between data cells and header cells](https://html.spec.whatwg.org/multipage/tables.html#header-and-data-cell-semantics)）と一致していなかったため修正しました。

## 問題

仕様では scope=rowgroup / colgroup のヘッダーは、同じグループ内であることに加えて以下の座標制約を満たすセルにのみ適用されます。

- `header.x ≤ principal.x + principal.width − 1`
- `header.y ≤ principal.y + principal.height − 1`

しかし実装では:

- `getRowGroupHeaderElements`: x / y の座標制約を一切持たず、同じ行グループ内のすべての rowgroup ヘッダーを割り当てていた
- `getColGroupHeaderElements`: x 制約が欠落し、y 制約も `< positionY`（仕様は `≤ principal.y + height − 1`）とずれていた

このため、ヘッダーよりも左の列（例: 仕様の例における最初の「ID」列）にまでヘッダーが誤って適用されていました。

### 仕様の例

```html
<table>
 <thead>
  <tr> <th> ID <th> Measurement <th> Average <th> Maximum
 <tbody>
  <tr> <td> <th scope=rowgroup> Cats <td> <td>
  <tr> <td> 93 <th> Legs <td> 3.5 <td> 4
  ...
```

仕様には「The headers with a scope attribute in the Row Group state apply to all the cells in their row group **other than the cells in the first column**」とあり、`Cats`(x=1) は ID 列(x=0)のセルには適用されません。修正前はこれが適用されてしまっていました。

## 修正内容

- `getRowGroupHeaderElements` / `getColGroupHeaderElements` に仕様どおりの x / y 座標制約を追加
- WHATWG 仕様の例に基づく回帰テストを追加（rowgroup・colgroup の両方）

## テスト

- `@a11y-visualizer/table`: 70 tests passed
- `@a11y-visualizer/rules`（table-header 等の利用側）: 1023 passed / 1 skipped
- `pnpm lint-fix` 適用済み

破壊的変更ではなく、仕様に沿った挙動への修正です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)