### PR TITLE
pnpm dev が dist の古い HTML スキャンで失敗する問題を修正

### DIFF
--- a/apps/browser_extension/wxt.config.ts
+++ b/apps/browser_extension/wxt.config.ts
@@ -13,6 +13,13 @@ export default defineConfig({
     css: {
       postcss: "./postcss.config.js",
     },
+    optimizeDeps: {
+      // Vite のデフォルトでは `**/*.html` をスキャンするため、過去の build /
+      // test / zip で生成された `dist/` 配下の古い HTML まで対象になり、
+      // ファイルが欠落していると ENOENT で dev サーバーが失敗する。
+      // ソースの entrypoints のみをスキャン対象にして dist を除外する。
+      entries: ["entrypoints/**/*.html"],
+    },
     test: {
       browser: {
         enabled: true,


### PR DESCRIPTION
## 概要

`pnpm dev` 実行時に、vite の依存スキャン（`optimizeDeps`）が `dist/` 配下の古い HTML を読みに行き、ファイルが欠落していると `ENOENT` で dev サーバーが起動に失敗する問題を修正します。

## 原因

vite はデフォルトでプロジェクト内の `**/*.html` を全てスキャン対象にします。そのため、過去の `build` / `test` / `zip` で生成された `dist/`（`chrome-mv3`, `chrome-mv3-test`, `firefox-mv2`, `safari-mv2` など）配下の HTML までスキャンされ、一部ファイルが欠落していると次のように失敗していました。

```
✘ [ERROR] ENOENT: no such file or directory, open '.../dist/chrome-mv3-dev/options.html' [plugin vite:dep-scan]
```

## 修正

`wxt.config.ts` の vite 設定に `optimizeDeps.entries` を追加し、スキャン対象をソースの `entrypoints/**/*.html` に限定して `dist/` を除外しました。

## 検証

- 修正前: stale な `dist` があると `ENOENT` で dev サーバーが失敗
- 修正後: stale な `dist` を残したままでも `✔ Built extension` で正常起動
- `pnpm lint-fix` 実行済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)