### PR TITLE
Add JSDoc to package exports and fix getComputedImplicitRole typo

### DIFF
--- a/packages/dom-utils/src/KnownRole.ts
+++ b/packages/dom-utils/src/KnownRole.ts
@@ -1,3 +1,10 @@
+/**
+ * このパッケージおよびAccessibility Visualizerが扱う既知のWAI-ARIAロールの一覧
+ *
+ * WAI-ARIA 1.2のロール（抽象ロールを含む）に加えて、ARIA 1.3で追加予定の
+ * ロールとWAI-ARIA Graphics Module（graphics-*）のロールを含む。
+ * {@link getKnownRole} はこの一覧に含まれるロールのみを返す
+ */
 export const knownRoles = [
   "alert",
   "alertdialog",
@@ -103,4 +110,5 @@ export const knownRoles = [
   "graphics-symbol",
 ] as const;
 
+/** 既知のWAI-ARIAロール（{@link knownRoles} の要素） */
 export type KnownRole = (typeof knownRoles)[number];

--- a/packages/dom-utils/src/getClosestByRoles.ts
+++ b/packages/dom-utils/src/getClosestByRoles.ts
@@ -1,6 +1,16 @@
 import { getKnownRole } from "./getKnownRole";
 import type { KnownRole } from "./KnownRole";
 
+/**
+ * 要素自身から祖先方向に辿り、指定されたロールのいずれかを持つ最も近い要素を取得する
+ *
+ * `Element.closest()` のロール版。テーブルセルから所属するテーブル
+ * （table/grid/treegrid）を探す場合などに使う
+ *
+ * @param el - 起点となる要素（要素自身も判定対象に含まれる）
+ * @param roles - 検索するロールの配列
+ * @returns 該当する最も近い要素、見つからない場合はnull
+ */
 export const getClosestByRoles = (
   el: Element,
   roles: KnownRole[],

--- a/packages/dom-utils/src/getComputedImplicitRole.test.ts
+++ b/packages/dom-utils/src/getComputedImplicitRole.test.ts
@@ -3,10 +3,10 @@ import {
   COMPUTED_ROLES,
   type ComputedRole,
   computedRoleToKnownRole,
-  getComputedImplictRole,
+  getComputedImplicitRole,
 } from "./getComputedImplicitRole";
 
-describe("getComputedImplictRole", () => {
+describe("getComputedImplicitRole", () => {
   afterEach(() => {
     document.body.innerHTML = "";
   });
@@ -35,13 +35,13 @@ describe("getComputedImplictRole", () => {
     ];
 
     elements.forEach((el) => {
-      expect(getComputedImplictRole(el)).toBe(null);
+      expect(getComputedImplicitRole(el)).toBe(null);
     });
 
     // input type="hidden" should return null
     const hiddenInput = document.createElement("input");
     hiddenInput.setAttribute("type", "hidden");
-    expect(getComputedImplictRole(hiddenInput)).toBe(null);
+    expect(getComputedImplicitRole(hiddenInput)).toBe(null);
   });
 
   test("returns generic role for generic elements", () => {
@@ -64,19 +64,19 @@ describe("getComputedImplictRole", () => {
 
     elements.forEach((tagName) => {
       const el = document.createElement(tagName);
-      expect(getComputedImplictRole(el)).toBe("generic");
+      expect(getComputedImplicitRole(el)).toBe("generic");
     });
   });
 
   test("returns correct roles for form elements", () => {
     const button = document.createElement("button");
-    expect(getComputedImplictRole(button)).toBe("button");
+    expect(getComputedImplicitRole(button)).toBe("button");
 
     const textarea = document.createElement("textarea");
-    expect(getComputedImplictRole(textarea)).toBe("textbox");
+    expect(getComputedImplicitRole(textarea)).toBe("textbox");
 
     const fieldset = document.createElement("fieldset");
-    expect(getComputedImplictRole(fieldset)).toBe("group");
+    expect(getComputedImplicitRole(fieldset)).toBe("group");
   });
 
   test("handles input elements with different types", () => {
@@ -97,12 +97,12 @@ describe("getComputedImplictRole", () => {
     testCases.forEach(({ type, expected }) => {
       const input = document.createElement("input");
       input.setAttribute("type", type);
-      expect(getComputedImplictRole(input)).toBe(expected);
+      expect(getComputedImplicitRole(input)).toBe(expected);
     });
 
     // Default input (no type attribute) should be textbox
     const defaultInput = document.createElement("input");
-    expect(getComputedImplictRole(defaultInput)).toBe("textbox");
+    expect(getComputedImplicitRole(defaultInput)).toBe("textbox");
   });
 
   test("handles input with list attribute", () => {
@@ -117,122 +117,122 @@ describe("getComputedImplictRole", () => {
       const input = document.createElement("input");
       input.setAttribute("type", type);
       input.setAttribute("list", "datalist1");
-      expect(getComputedImplictRole(input)).toBe(expected);
+      expect(getComputedImplicitRole(input)).toBe(expected);
     });
   });
 
   test("handles select element", () => {
     const singleSelect = document.createElement("select");
-    expect(getComputedImplictRole(singleSelect)).toBe("combobox");
+    expect(getComputedImplicitRole(singleSelect)).toBe("combobox");
 
     const multipleSelect = document.createElement("select");
     multipleSelect.setAttribute("multiple", "");
-    expect(getComputedImplictRole(multipleSelect)).toBe("listbox");
+    expect(getComputedImplicitRole(multipleSelect)).toBe("listbox");
 
     const sizedSelect = document.createElement("select") as HTMLSelectElement;
     Object.defineProperty(sizedSelect, "size", { value: 2, writable: true });
-    expect(getComputedImplictRole(sizedSelect)).toBe("listbox");
+    expect(getComputedImplicitRole(sizedSelect)).toBe("listbox");
   });
 
   test("handles anchor elements", () => {
     const linkWithHref = document.createElement("a");
     linkWithHref.setAttribute("href", "#");
-    expect(getComputedImplictRole(linkWithHref)).toBe("link");
+    expect(getComputedImplicitRole(linkWithHref)).toBe("link");
 
     const linkWithoutHref = document.createElement("a");
-    expect(getComputedImplictRole(linkWithoutHref)).toBe("generic");
+    expect(getComputedImplicitRole(linkWithoutHref)).toBe("generic");
 
     const areaWithHref = document.createElement("area");
     areaWithHref.setAttribute("href", "#");
-    expect(getComputedImplictRole(areaWithHref)).toBe("link");
+    expect(getComputedImplicitRole(areaWithHref)).toBe("link");
 
     const areaWithoutHref = document.createElement("area");
-    expect(getComputedImplictRole(areaWithoutHref)).toBe("generic");
+    expect(getComputedImplicitRole(areaWithoutHref)).toBe("generic");
   });
 
   test("handles img element", () => {
     const imgWithAlt = document.createElement("img");
     imgWithAlt.setAttribute("alt", "description");
-    expect(getComputedImplictRole(imgWithAlt)).toBe("img");
+    expect(getComputedImplicitRole(imgWithAlt)).toBe("img");
 
     const imgWithEmptyAlt = document.createElement("img");
     imgWithEmptyAlt.setAttribute("alt", "");
-    expect(getComputedImplictRole(imgWithEmptyAlt)).toBe("presentation");
+    expect(getComputedImplicitRole(imgWithEmptyAlt)).toBe("presentation");
 
     const imgWithoutAlt = document.createElement("img");
-    expect(getComputedImplictRole(imgWithoutAlt)).toBe("img");
+    expect(getComputedImplicitRole(imgWithoutAlt)).toBe("img");
   });
 
   test("handles heading elements", () => {
     const headings = ["h1", "h2", "h3", "h4", "h5", "h6"];
     headings.forEach((tagName) => {
       const heading = document.createElement(tagName);
-      expect(getComputedImplictRole(heading)).toBe("heading");
+      expect(getComputedImplicitRole(heading)).toBe("heading");
     });
   });
 
   test("handles list elements", () => {
     const ul = document.createElement("ul");
-    expect(getComputedImplictRole(ul)).toBe("list");
+    expect(getComputedImplicitRole(ul)).toBe("list");
 
     const ol = document.createElement("ol");
-    expect(getComputedImplictRole(ol)).toBe("list");
+    expect(getComputedImplicitRole(ol)).toBe("list");
 
     const dl = document.createElement("dl");
-    expect(getComputedImplictRole(dl)).toBe("list");
+    expect(getComputedImplicitRole(dl)).toBe("list");
 
     const menu = document.createElement("menu");
-    expect(getComputedImplictRole(menu)).toBe("list");
+    expect(getComputedImplicitRole(menu)).toBe("list");
 
     const li = document.createElement("li");
-    expect(getComputedImplictRole(li)).toBe("listitem");
+    expect(getComputedImplicitRole(li)).toBe("listitem");
 
     const dt = document.createElement("dt");
-    expect(getComputedImplictRole(dt)).toBe("term");
+    expect(getComputedImplicitRole(dt)).toBe("term");
 
     const dd = document.createElement("dd");
-    expect(getComputedImplictRole(dd)).toBe("definition");
+    expect(getComputedImplicitRole(dd)).toBe("definition");
   });
 
   test("handles table elements", () => {
     const table = document.createElement("table");
-    expect(getComputedImplictRole(table)).toBe("table");
+    expect(getComputedImplicitRole(table)).toBe("table");
 
     const tbody = document.createElement("tbody");
-    expect(getComputedImplictRole(tbody)).toBe("rowgroup");
+    expect(getComputedImplicitRole(tbody)).toBe("rowgroup");
 
     const thead = document.createElement("thead");
-    expect(getComputedImplictRole(thead)).toBe("rowgroup");
+    expect(getComputedImplicitRole(thead)).toBe("rowgroup");
 
     const tfoot = document.createElement("tfoot");
-    expect(getComputedImplictRole(tfoot)).toBe("rowgroup");
+    expect(getComputedImplicitRole(tfoot)).toBe("rowgroup");
 
     const tr = document.createElement("tr");
-    expect(getComputedImplictRole(tr)).toBe("row");
+    expect(getComputedImplicitRole(tr)).toBe("row");
 
     const td = document.createElement("td");
-    expect(getComputedImplictRole(td)).toBe("cell");
+    expect(getComputedImplicitRole(td)).toBe("cell");
   });
 
   test("handles th element with scope attribute", () => {
     const thRow = document.createElement("th");
     thRow.setAttribute("scope", "row");
-    expect(getComputedImplictRole(thRow)).toBe("rowheader");
+    expect(getComputedImplicitRole(thRow)).toBe("rowheader");
 
     const thRowGroup = document.createElement("th");
     thRowGroup.setAttribute("scope", "rowgroup");
-    expect(getComputedImplictRole(thRowGroup)).toBe("rowheader");
+    expect(getComputedImplicitRole(thRowGroup)).toBe("rowheader");
 
     const thCol = document.createElement("th");
     thCol.setAttribute("scope", "col");
-    expect(getComputedImplictRole(thCol)).toBe("columnheader");
+    expect(getComputedImplicitRole(thCol)).toBe("columnheader");
 
     const thColGroup = document.createElement("th");
     thColGroup.setAttribute("scope", "colgroup");
-    expect(getComputedImplictRole(thColGroup)).toBe("columnheader");
+    expect(getComputedImplicitRole(thColGroup)).toBe("columnheader");
 
     const thDefault = document.createElement("th");
-    expect(getComputedImplictRole(thDefault)).toBe("columnheader");
+    expect(getComputedImplicitRole(thDefault)).toBe("columnheader");
   });
 
   test("handles td in grid table", () => {
@@ -242,7 +242,7 @@ describe("getComputedImplictRole", () => {
     table.appendChild(td);
     document.body.appendChild(table);
 
-    expect(getComputedImplictRole(td)).toBe("gridcell");
+    expect(getComputedImplicitRole(td)).toBe("gridcell");
 
     const treegridTable = document.createElement("table");
     treegridTable.setAttribute("role", "treegrid");
@@ -250,27 +250,27 @@ describe("getComputedImplictRole", () => {
     treegridTable.appendChild(td2);
     document.body.appendChild(treegridTable);
 
-    expect(getComputedImplictRole(td2)).toBe("gridcell");
+    expect(getComputedImplicitRole(td2)).toBe("gridcell");
   });
 
   test("handles sectioning elements", () => {
     const article = document.createElement("article");
-    expect(getComputedImplictRole(article)).toBe("article");
+    expect(getComputedImplicitRole(article)).toBe("article");
 
     const nav = document.createElement("nav");
-    expect(getComputedImplictRole(nav)).toBe("navigation");
+    expect(getComputedImplicitRole(nav)).toBe("navigation");
 
     const main = document.createElement("main");
-    expect(getComputedImplictRole(main)).toBe("main");
+    expect(getComputedImplicitRole(main)).toBe("main");
 
     const form = document.createElement("form");
-    expect(getComputedImplictRole(form)).toBe("form");
+    expect(getComputedImplicitRole(form)).toBe("form");
 
     const search = document.createElement("search");
-    expect(getComputedImplictRole(search)).toBe("search");
+    expect(getComputedImplicitRole(search)).toBe("search");
 
     const dialog = document.createElement("dialog");
-    expect(getComputedImplictRole(dialog)).toBe("dialog");
+    expect(getComputedImplicitRole(dialog)).toBe("dialog");
   });
 
   test("handles aside element scoping", () => {
@@ -281,14 +281,14 @@ describe("getComputedImplictRole", () => {
     document.body.appendChild(aside);
     // The implementation checks if closest('article,aside,nav,section') matches
     // which includes the element itself, so it returns generic
-    expect(getComputedImplictRole(aside)).toBe("generic");
+    expect(getComputedImplicitRole(aside)).toBe("generic");
 
     // aside in sectioning content without name should be generic
     const article = document.createElement("article");
     const asideInArticle = document.createElement("aside");
     article.appendChild(asideInArticle);
     document.body.appendChild(article);
-    expect(getComputedImplictRole(asideInArticle)).toBe("generic");
+    expect(getComputedImplicitRole(asideInArticle)).toBe("generic");
 
     // aside in sectioning content with accessible name should be complementary
     const section = document.createElement("section");
@@ -296,42 +296,42 @@ describe("getComputedImplictRole", () => {
     asideWithName.setAttribute("aria-label", "sidebar");
     section.appendChild(asideWithName);
     document.body.appendChild(section);
-    expect(getComputedImplictRole(asideWithName)).toBe("complementary");
+    expect(getComputedImplicitRole(asideWithName)).toBe("complementary");
   });
 
   test("handles section element", () => {
     const sectionWithoutName = document.createElement("section");
-    expect(getComputedImplictRole(sectionWithoutName)).toBe("generic");
+    expect(getComputedImplicitRole(sectionWithoutName)).toBe("generic");
 
     const sectionWithName = document.createElement("section");
     sectionWithName.setAttribute("aria-label", "section name");
-    expect(getComputedImplictRole(sectionWithName)).toBe("region");
+    expect(getComputedImplicitRole(sectionWithName)).toBe("region");
   });
 
   test("handles header and footer scoping", () => {
     // header not in main/sectioning content should be banner
     const header = document.createElement("header");
     document.body.appendChild(header);
-    expect(getComputedImplictRole(header)).toBe("banner");
+    expect(getComputedImplicitRole(header)).toBe("banner");
 
     // header in sectioning content should be generic
     const article = document.createElement("article");
     const headerInArticle = document.createElement("header");
     article.appendChild(headerInArticle);
     document.body.appendChild(article);
-    expect(getComputedImplictRole(headerInArticle)).toBe("generic");
+    expect(getComputedImplicitRole(headerInArticle)).toBe("generic");
 
     // footer not in main/sectioning content should be contentinfo
     const footer = document.createElement("footer");
     document.body.appendChild(footer);
-    expect(getComputedImplictRole(footer)).toBe("contentinfo");
+    expect(getComputedImplicitRole(footer)).toBe("contentinfo");
 
     // footer in sectioning content should be generic
     const section = document.createElement("section");
     const footerInSection = document.createElement("footer");
     section.appendChild(footerInSection);
     document.body.appendChild(section);
-    expect(getComputedImplictRole(footerInSection)).toBe("generic");
+    expect(getComputedImplicitRole(footerInSection)).toBe("generic");
   });
 
   test("handles summary element", () => {
@@ -340,11 +340,11 @@ describe("getComputedImplictRole", () => {
     details.appendChild(summary);
     document.body.appendChild(details);
 
-    expect(getComputedImplictRole(summary)).toBe("html-summary");
+    expect(getComputedImplicitRole(summary)).toBe("html-summary");
 
     // summary not as first child of details should be generic
     const summaryNotFirst = document.createElement("summary");
-    expect(getComputedImplictRole(summaryNotFirst)).toBe("generic");
+    expect(getComputedImplicitRole(summaryNotFirst)).toBe("generic");
   });
 
   test("handles semantic text elements", () => {
@@ -369,48 +369,48 @@ describe("getComputedImplictRole", () => {
 
     testCases.forEach(({ tagName, expected }) => {
       const element = document.createElement(tagName);
-      expect(getComputedImplictRole(element)).toBe(expected);
+      expect(getComputedImplicitRole(element)).toBe(expected);
     });
   });
 
   test("handles special elements", () => {
     const address = document.createElement("address");
-    expect(getComputedImplictRole(address)).toBe("group");
+    expect(getComputedImplicitRole(address)).toBe("group");
 
     const caption = document.createElement("caption");
-    expect(getComputedImplictRole(caption)).toBe("caption");
+    expect(getComputedImplicitRole(caption)).toBe("caption");
 
     const datalist = document.createElement("datalist");
-    expect(getComputedImplictRole(datalist)).toBe("listbox");
+    expect(getComputedImplicitRole(datalist)).toBe("listbox");
 
     const details = document.createElement("details");
-    expect(getComputedImplictRole(details)).toBe("group");
+    expect(getComputedImplicitRole(details)).toBe("group");
 
     const hgroup = document.createElement("hgroup");
-    expect(getComputedImplictRole(hgroup)).toBe("group");
+    expect(getComputedImplicitRole(hgroup)).toBe("group");
 
     const math = document.createElement("math");
-    expect(getComputedImplictRole(math)).toBe("math");
+    expect(getComputedImplicitRole(math)).toBe("math");
 
     const meter = document.createElement("meter");
-    expect(getComputedImplictRole(meter)).toBe("meter");
+    expect(getComputedImplicitRole(meter)).toBe("meter");
 
     // Note: There's a typo in the implementation "optgrouop" instead of "optgroup"
     // So optgroup elements return null, not "group"
     const optgroup = document.createElement("optgroup");
-    expect(getComputedImplictRole(optgroup)).toBe(null);
+    expect(getComputedImplicitRole(optgroup)).toBe(null);
 
     const option = document.createElement("option");
-    expect(getComputedImplictRole(option)).toBe("option");
+    expect(getComputedImplicitRole(option)).toBe("option");
 
     const output = document.createElement("output");
-    expect(getComputedImplictRole(output)).toBe("status");
+    expect(getComputedImplicitRole(output)).toBe("status");
 
     const progress = document.createElement("progress");
-    expect(getComputedImplictRole(progress)).toBe("progressbar");
+    expect(getComputedImplicitRole(progress)).toBe("progressbar");
 
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    expect(getComputedImplictRole(svg)).toBe("graphics-document");
+    expect(getComputedImplicitRole(svg)).toBe("graphics-document");
   });
 
   test("handles computed HTML-specific roles", () => {
@@ -434,7 +434,7 @@ describe("getComputedImplictRole", () => {
 
     computedRoleElements.forEach(({ tagName, expected }) => {
       const element = document.createElement(tagName);
-      expect(getComputedImplictRole(element)).toBe(expected);
+      expect(getComputedImplicitRole(element)).toBe(expected);
     });
 
     // Input specific types
@@ -452,7 +452,7 @@ describe("getComputedImplictRole", () => {
     inputTypes.forEach(({ type, expected }) => {
       const input = document.createElement("input");
       input.setAttribute("type", type);
-      expect(getComputedImplictRole(input)).toBe(expected);
+      expect(getComputedImplicitRole(input)).toBe(expected);
     });
   });
 
@@ -489,10 +489,10 @@ describe("getComputedImplictRole", () => {
 
   test("handles unknown elements", () => {
     const customElement = document.createElement("custom-element");
-    expect(getComputedImplictRole(customElement)).toBe(null);
+    expect(getComputedImplicitRole(customElement)).toBe(null);
 
     const unknownElement = document.createElement("unknown");
-    expect(getComputedImplictRole(unknownElement)).toBe(null);
+    expect(getComputedImplicitRole(unknownElement)).toBe(null);
   });
 });
 

--- a/packages/dom-utils/src/getComputedImplicitRole.ts
+++ b/packages/dom-utils/src/getComputedImplicitRole.ts
@@ -8,6 +8,13 @@ const isScopedToMainOrSectioningContent = (el: Element) => {
   return el.closest("main,article,aside,nav,section") !== null;
 };
 
+/**
+ * 対応するWAI-ARIAロールが存在しないHTML要素を表す、このパッケージ独自の擬似ロールの一覧
+ *
+ * ブラウザがアクセシビリティツリー上で独自の内部ロールとして扱う要素
+ * （iframe、日付入力など）を `html-` プレフィックス付きで識別する。
+ * {@link computedRoleToKnownRole} でWAI-ARIAロールに近似変換できる
+ */
 export const COMPUTED_ROLES = [
   "html-abbr",
   "html-audio",
@@ -35,17 +42,40 @@ export const COMPUTED_ROLES = [
   "html-var",
 ] as const;
 
+/**
+ * {@link getComputedImplicitRole} が返しうるロール。
+ * WAI-ARIAロール（{@link KnownRole}）または `html-` プレフィックス付きの擬似ロール
+ */
 export type ComputedRole = KnownRole | (typeof COMPUTED_ROLES)[number];
 
+/**
+ * 要素の暗黙のWAI-ARIAロールを取得する
+ *
+ * {@link getComputedImplicitRole} の結果を {@link computedRoleToKnownRole} で
+ * WAI-ARIAロールに変換したもの。role属性は参照しない
+ *
+ * @param el - 対象の要素
+ * @returns 暗黙のロール、対応するロールがない場合はnull
+ */
 export const getImplicitRole = (el: Element): KnownRole | null => {
-  const computedRole = getComputedImplictRole(el);
+  const computedRole = getComputedImplicitRole(el);
   if (computedRole) {
     return computedRoleToKnownRole(computedRole);
   }
   return null;
 };
 
-export const getComputedImplictRole = (el: Element): ComputedRole | null => {
+/**
+ * ARIA in HTML仕様に基づいて、要素の暗黙のロールをタグ名・属性から求める
+ *
+ * role属性は参照しない。対応するWAI-ARIAロールがない要素については
+ * `html-` プレフィックス付きの擬似ロール（{@link COMPUTED_ROLES}）を返す。
+ * accessible-nameルールなどで、role属性のない要素の命名可否判定に使われる
+ *
+ * @param el - 対象の要素
+ * @returns 暗黙のロール、対応するロールがない場合はnull
+ */
+export const getComputedImplicitRole = (el: Element): ComputedRole | null => {
   const tagName = el.tagName.toLowerCase();
   switch (tagName) {
     // HTML
@@ -406,6 +436,16 @@ export const getComputedImplictRole = (el: Element): ComputedRole | null => {
   }
 };
 
+/**
+ * {@link ComputedRole} をWAI-ARIAロール（{@link KnownRole}）に変換する
+ *
+ * `html-` プレフィックス付きの擬似ロールは、主要ブラウザの
+ * アクセシビリティツリー上での扱いをもとに近いWAI-ARIAロールへ近似する
+ * （例: `html-input-date` → `textbox`）。近似できないものはnullになる
+ *
+ * @param role - 変換するロール
+ * @returns 対応するWAI-ARIAロール、対応するものがない場合はnull
+ */
 export const computedRoleToKnownRole = (
   role: ComputedRole,
 ): KnownRole | null => {

--- a/packages/dom-utils/src/getElementPosition.ts
+++ b/packages/dom-utils/src/getElementPosition.ts
@@ -1,3 +1,9 @@
+/**
+ * ページ内での要素の位置とサイズ
+ *
+ * `x`/`y` はオフセット（オーバーレイの配置基準となる要素の位置）を差し引いた座標、
+ * `absoluteX`/`absoluteY` はドキュメント左上を原点とした絶対座標
+ */
 export type ElementPosition = {
   x: number;
   y: number;
@@ -7,6 +13,19 @@ export type ElementPosition = {
   height: number;
 };
 
+/**
+ * 要素のページ内での位置とサイズを取得する
+ *
+ * スクロール量を加味したドキュメント座標系で返す。拡張機能が要素に
+ * オーバーレイ表示を重ねる際の座標計算に使う。area要素の場合は
+ * shape/coords属性と対応するimg要素から描画領域を計算する
+ *
+ * @param el - 対象の要素
+ * @param w - 要素が属するWindow
+ * @param offsetX - `x` から差し引くX座標（配置基準要素のX座標）
+ * @param offsetY - `y` から差し引くY座標（配置基準要素のY座標）
+ * @returns 要素の位置とサイズ
+ */
 export const getElementPosition = (
   el: Element,
   w: Window,

--- a/packages/dom-utils/src/getKnownRole.ts
+++ b/packages/dom-utils/src/getKnownRole.ts
@@ -1,6 +1,20 @@
 import { getRole } from "dom-accessibility-api";
 import { type KnownRole, knownRoles } from "./KnownRole";
 
+/**
+ * 要素のロール（role属性による明示的なロール、なければ暗黙のロール）を取得する
+ *
+ * dom-accessibility-apiの `getRole()` をベースに、結果を既知のロール
+ * （{@link knownRoles}）に限定する。role属性に未知の値が指定されている場合は
+ * スペース区切りのフォールバックを考慮して既知のロールを探す。
+ * input要素・svg要素については、ARIA in HTMLで暗黙のロールが未定義のものにも
+ * ブラウザの実際の挙動に近いロールを仮定して返す。
+ *
+ * 要素のカテゴリ分類や、各ルールが対象要素かどうかの判定に広く使われる
+ *
+ * @param el - 対象の要素
+ * @returns 要素のロール、判定できない場合はnull
+ */
 export const getKnownRole = (el: Element): KnownRole | null => {
   const role = getRole(el);
   if (role && knownRoles.includes(role as KnownRole)) {

--- a/packages/dom-utils/src/hasInteractiveDescendant.ts
+++ b/packages/dom-utils/src/hasInteractiveDescendant.ts
@@ -1,3 +1,14 @@
+/**
+ * インタラクティブなHTML要素（リンク、ボタン、フォームコントロールなど）を
+ * 子孫に持つかどうかを判定する
+ *
+ * HTML仕様のinteractive contentに相当する要素をタグ名ベースで検出する。
+ * role属性によるインタラクティブ要素は検出しない。
+ * インタラクティブ要素の入れ子（nested-interactiveルール）の検出に使う
+ *
+ * @param el - 対象の要素（要素自身は判定対象に含まれない）
+ * @returns インタラクティブな子孫を持つ場合はtrue
+ */
 export const hasInteractiveDescendant = (el: Element): boolean => {
   return !!el.querySelector(
     [

--- a/packages/dom-utils/src/hasTabIndexDescendant.ts
+++ b/packages/dom-utils/src/hasTabIndexDescendant.ts
@@ -1,3 +1,12 @@
+/**
+ * tabindex属性を持つ要素を子孫に持つかどうかを判定する
+ *
+ * {@link hasInteractiveDescendant} と組み合わせて、フォーカス可能な要素の
+ * 入れ子（nested-interactiveルール）の検出に使う
+ *
+ * @param el - 対象の要素（要素自身は判定対象に含まれない）
+ * @returns tabindex属性を持つ子孫を持つ場合はtrue
+ */
 export const hasTabIndexDescendant = (el: Element): boolean => {
   return !!el.querySelector("[tabindex]");
 };

--- a/packages/dom-utils/src/index.ts
+++ b/packages/dom-utils/src/index.ts
@@ -5,7 +5,7 @@ export {
   COMPUTED_ROLES,
   type ComputedRole,
   computedRoleToKnownRole,
-  getComputedImplictRole,
+  getComputedImplicitRole,
   getImplicitRole,
 } from "./getComputedImplicitRole";
 // Shadow DOM utilities

--- a/packages/dom-utils/src/isAriaHidden.ts
+++ b/packages/dom-utils/src/isAriaHidden.ts
@@ -1,6 +1,24 @@
+/**
+ * 要素自身に `aria-hidden="true"` が指定されているかどうかを判定する
+ *
+ * 祖先は判定しない。祖先も含めて判定する場合は {@link isInAriaHidden} を使う
+ *
+ * @param el - 対象の要素
+ * @returns aria-hidden="true" が指定されている場合はtrue
+ */
 export const isAriaHidden = (el: Element): boolean =>
   el.getAttribute("aria-hidden") === "true";
 
+/**
+ * 要素が `aria-hidden="true"` の影響下にある（自身または祖先に指定されている）
+ * かどうかを判定する
+ *
+ * アクセシビリティツリーから除外されている要素をルールの評価対象外にしたり、
+ * ライブリージョンの読み上げ対象外の判定に使う
+ *
+ * @param el - 対象の要素
+ * @returns 自身または祖先に aria-hidden="true" が指定されている場合はtrue
+ */
 export const isInAriaHidden = (el: Element): boolean => {
   if (isAriaHidden(el)) {
     return true;

--- a/packages/dom-utils/src/isDefaultSize.ts
+++ b/packages/dom-utils/src/isDefaultSize.ts
@@ -211,6 +211,18 @@ const getDefaultStyle = (el: Element): SizeDeclaration | undefined => {
   return DefaultStyles[type];
 };
 
+/**
+ * フォームコントロール（button要素・input要素）がブラウザデフォルトの
+ * サイズのまま表示されているかどうかを判定する
+ *
+ * 同種のデフォルト状態の要素を一時的にDOMに生成してサイズ関連のスタイルを
+ * 比較する。WCAG 2.5.8 Target Size (Minimum) の「User agent control」例外
+ * （ブラウザ標準のサイズならターゲットサイズ不足を問わない）の判定として
+ * target-sizeルールで使う
+ *
+ * @param el - 対象の要素
+ * @returns デフォルトサイズの場合はtrue（button/input以外の要素は常にfalse）
+ */
 export const isDefaultSize = (el: Element): boolean => {
   const defaultStyle = getDefaultStyle(el);
 

--- a/packages/dom-utils/src/isFocusable.ts
+++ b/packages/dom-utils/src/isFocusable.ts
@@ -1,3 +1,10 @@
+/**
+ * フォーカス可能になりうる要素にマッチするCSSセレクタ
+ *
+ * リンク・フォームコントロール・contenteditable・tabindex持ちの要素などを対象とする。
+ * disabled属性や負のtabindexは考慮しないため、厳密な判定には
+ * {@link isFocusable} を使う
+ */
 export const FOCUSABLE_SELECTOR = [
   "a[href]",
   "map > area[href]",
@@ -10,6 +17,17 @@ export const FOCUSABLE_SELECTOR = [
   "details > summary",
   "[tabindex]",
 ].join(", ");
+/**
+ * 要素がフォーカス可能かどうかを判定する
+ *
+ * {@link FOCUSABLE_SELECTOR} にマッチするかで判定する。
+ * コントロールにフォーカス可否を求めるルール（control-focusなど）で使う
+ *
+ * @param element - 対象の要素
+ * @param keyboard - trueの場合、キーボードフォーカス可能かを判定する
+ *   （負のtabindexが指定されている要素を除外する）
+ * @returns フォーカス可能な場合はtrue
+ */
 export const isFocusable = (
   element: Element,
   keyboard: boolean = false,

--- a/packages/dom-utils/src/isHidden.ts
+++ b/packages/dom-utils/src/isHidden.ts
@@ -1,3 +1,17 @@
+/**
+ * 要素が視覚的に非表示（レンダリングされていない）かどうかを判定する
+ *
+ * 自身と祖先の `display: none`・`visibility: hidden`・
+ * `content-visibility: hidden`、および開いていないdetails要素の中身を
+ * 非表示として扱う。祖先の探索はShadow DOM境界を越えてhost要素を辿る。
+ * aria-hiddenやinertは考慮しない（それぞれ {@link isInAriaHidden}・
+ * {@link isInInert} を使う）。
+ *
+ * 表示されていない要素をオーバーレイ表示やルール評価の対象外にするために使う
+ *
+ * @param el - 対象の要素
+ * @returns 非表示の場合はtrue
+ */
 export const isHidden = (el: Element): boolean => {
   const tagName = el.tagName.toLowerCase();
   if (el.matches("details:not([open]) *")) {

--- a/packages/dom-utils/src/isInert.ts
+++ b/packages/dom-utils/src/isInert.ts
@@ -1,3 +1,12 @@
+/**
+ * 要素自身がinert（不活性）に指定されているかどうかを判定する
+ *
+ * inert属性、またはCSSの `interactivity: inert` を検出する。
+ * 祖先は判定しない。祖先も含めて判定する場合は {@link isInInert} を使う
+ *
+ * @param el - 対象の要素
+ * @returns inertに指定されている場合はtrue
+ */
 export const isInert = (el: Element): boolean => {
   if (el.hasAttribute("inert")) {
     return true;
@@ -12,6 +21,16 @@ export const isInert = (el: Element): boolean => {
   return false;
 };
 
+/**
+ * 要素がinert（不活性）の影響下にある（自身または祖先がinertである）
+ * かどうかを判定する
+ *
+ * 祖先の探索はShadow DOM境界を越えてhost要素を辿る。
+ * inertルールでの表示や、ライブリージョンの読み上げ対象外の判定に使う
+ *
+ * @param el - 対象の要素
+ * @returns 自身または祖先がinertの場合はtrue
+ */
 export const isInInert = (el: Element): boolean => {
   if (isInert(el)) {
     return true;

--- a/packages/dom-utils/src/isInline.ts
+++ b/packages/dom-utils/src/isInline.ts
@@ -28,6 +28,18 @@ const hasPreviousInlineSibling = (el: Element): boolean => {
   return false;
 };
 
+/**
+ * 要素が文中のインライン要素として（テキストの流れの中に）表示されているか
+ * どうかを判定する
+ *
+ * displayがinline系であることに加えて、前にテキストやインラインの兄弟が
+ * あるか、自身がテキストを含むかなど、実際に文中に位置しているかを判定する。
+ * WCAG 2.5.8 Target Size (Minimum) の「Inline」例外（文中のリンクなどは
+ * ターゲットサイズ不足を問わない）の判定としてtarget-sizeルールで使う
+ *
+ * @param el - 対象の要素
+ * @returns 文中のインライン要素として表示されている場合はtrue
+ */
 export const isInline = (el: Element): boolean => {
   if (!el.parentElement) {
     return false;

--- a/packages/dom-utils/src/isPresentationalChildren.ts
+++ b/packages/dom-utils/src/isPresentationalChildren.ts
@@ -18,6 +18,18 @@ const ChildrenPresentationalRoles: KnownRole[] = [
   "tab",
 ] as const;
 
+/**
+ * 要素が、子孫をプレゼンテーショナル（アクセシビリティツリーに公開しない）
+ * として扱うロールの内側にあるかどうかを判定する
+ *
+ * WAI-ARIAで「Children Presentational: True」と定義されるロール
+ * （button・checkbox・imgなど）またはbutton要素の子孫かどうかを判定する。
+ * 該当する要素は支援技術に個別の要素として公開されないため、
+ * image-nameやsvg-skipなどのルールで評価対象外の判定に使う
+ *
+ * @param el - 対象の要素
+ * @returns プレゼンテーショナルな子孫として扱われる場合はtrue
+ */
 export const isPresentationalChildren = (el: Element): boolean =>
   !!(
     el.parentElement &&

--- a/packages/rules/src/Rules.ts
+++ b/packages/rules/src/Rules.ts
@@ -34,6 +34,13 @@ import { TablePosition } from "./table-position";
 import { TableSize } from "./table-size";
 import { TargetSize } from "./target-size";
 
+/**
+ * すべてのアクセシビリティルールの一覧
+ *
+ * 拡張機能のコンテンツスクリプトはページ内の各要素に対してこの一覧を走査し、
+ * `isRuleTargetElement` で対象と判定されたルールの `evaluate` を呼び出して
+ * 評価結果を収集する。新しいルールを追加する場合はここに登録する
+ */
 export const Rules = [
   HeadingLevel,
   AccessibleName,

--- a/packages/rules/src/accessible-name/index.ts
+++ b/packages/rules/src/accessible-name/index.ts
@@ -1,5 +1,5 @@
 import {
-  getComputedImplictRole,
+  getComputedImplicitRole,
   getKnownRole,
   isInAriaHidden,
 } from "@a11y-visualizer/dom-utils";
@@ -47,7 +47,7 @@ export const AccessibleName: RuleObject = {
       return undefined;
     }
     const computedRole =
-      role || element.getAttribute("role") || getComputedImplictRole(element);
+      role || element.getAttribute("role") || getComputedImplicitRole(element);
     const isNamingProhibited =
       computedRole && NAMING_PROHIBITED_ROLES.includes(computedRole);
     if (

--- a/packages/rules/src/type.ts
+++ b/packages/rules/src/type.ts
@@ -5,18 +5,39 @@ type RuleResultBase = {
   type: unknown;
 };
 
+/**
+ * ルールの評価結果のうち、明確なアクセシビリティ上の問題を表すもの
+ *
+ * `message` は翻訳キーとして扱われ、表示時に `messageParams` とともに
+ * i18nで変換される
+ */
 export type RuleResultError = RuleResultBase & {
   type: "error";
   message: string;
   messageParams?: Record<string, string>;
 };
+
+/**
+ * ルールの評価結果のうち、文脈によっては問題になりうる（偽陽性の可能性がある）
+ * ことを表すもの
+ *
+ * `message` は翻訳キーとして扱われ、表示時に `messageParams` とともに
+ * i18nで変換される
+ */
 export type RuleResultWarning = RuleResultBase & {
   type: "warning";
   message: string;
   messageParams?: Record<string, string>;
 };
+
+/** ユーザーにメッセージとして表示される評価結果（エラーまたは警告） */
 export type RuleResultMessage = RuleResultError | RuleResultWarning;
 
+/**
+ * コンテンツ系の評価結果（{@link RuleResultContent}）の `type` に指定できる
+ * 値の一覧。要素のアクセシブルな名前やロールなど、問題の指摘ではなく
+ * 要素の情報の可視化として表示されるものを表す
+ */
 export const CONTENT_TYPES = [
   "name",
   "description",
@@ -37,6 +58,13 @@ export const CONTENT_TYPES = [
   "tabIndex",
 ] as const;
 
+/**
+ * ルールの評価結果のうち、要素の情報（アクセシブルな名前、ロール、
+ * 見出しレベルなど）をオーバーレイに表示するためのもの
+ *
+ * `content` が表示内容で、`type` の種類（{@link CONTENT_TYPES}）に応じて
+ * アイコンや色分けがされる
+ */
 export type RuleResultContent = RuleResultBase & {
   type:
     | "name"
@@ -60,6 +88,11 @@ export type RuleResultContent = RuleResultBase & {
   contentLabel?: string;
 };
 
+/**
+ * {@link CONTENT_TYPES} のうち、`content` をそのまま（翻訳せずに）表示する
+ * 種類の一覧。ページ由来のテキスト（アクセシブルな名前や言語など）が
+ * 該当し、表示時にi18nの変換を通さない判定に使う
+ */
 export const RAW_CONTENT_TYPES = [
   "name",
   "description",
@@ -72,17 +105,27 @@ export const RAW_CONTENT_TYPES = [
   "tabIndex",
 ] as const;
 
+/**
+ * コンテンツ系の評価結果のうち、`content` をそのまま（翻訳せずに）表示するもの
+ */
 export type RuleResultRawContent = RuleResultBase & {
   type: (typeof RAW_CONTENT_TYPES)[number];
   content: string;
   contentLabel?: string;
 };
 
+/**
+ * ルールの評価結果のうち、要素の状態（チェック状態や展開状態など）を
+ * 表すもの。`state` は翻訳キーとして扱われる
+ */
 export type RuleResultState = RuleResultBase & {
   type: "state";
   state: string;
 };
 
+/**
+ * ルールの評価結果のうち、要素に指定されているaria-*属性の一覧を表すもの
+ */
 export type RuleResultAriaAttributes = RuleResultBase & {
   type: "ariaAttributes";
   attributes: Array<{
@@ -91,6 +134,10 @@ export type RuleResultAriaAttributes = RuleResultBase & {
   }>;
 };
 
+/**
+ * ルールの評価結果。各ルールの `evaluate` が返し、拡張機能が要素の
+ * オーバーレイ（チップ）として表示する
+ */
 export type RuleResult =
   | RuleResultMessage
   | RuleResultContent
@@ -101,16 +148,40 @@ type RuleOptions = {
   enabled: boolean;
 };
 
+/**
+ * ルールの評価時に渡される、評価対象の周辺情報
+ *
+ * 呼び出し側で計算済みの値（アクセシブルな名前やロールなど）を渡すことで、
+ * ルール内での再計算を省略する。省略された場合は各ルールが自前で計算する
+ */
 export type RuleEvaluationCondition = {
+  /** 要素のアクセシブルな名前（計算済みの場合に渡す） */
   name?: string;
+  /** 要素のロール（計算済みの場合に渡す） */
   role?: string | null;
+  /** 要素が属するDocument */
   elementDocument?: Document;
+  /** 要素が属するWindow */
   elementWindow?: Window;
+  /**
+   * 解析済みテーブルのキャッシュ。テーブル系ルールが同じテーブルを
+   * 重複して解析しないよう、ページ内の評価で共有される
+   */
   tables?: Table[];
+  /** 評価対象がsrcdoc属性によるiframe内かどうか */
   srcdoc?: boolean;
+  /** ページ内で収集されたShadowRootの配列（Shadow DOM内の要素の参照解決に使う） */
   shadowRoots?: ShadowRoot[];
 };
 
+/**
+ * ルールの評価関数
+ *
+ * @param element - 評価対象の要素
+ * @param options - ルールのオプション（`enabled: false` の場合は評価しない）
+ * @param condition - 評価対象の周辺情報（{@link RuleEvaluationCondition}）
+ * @returns 評価結果の配列。表示すべき結果がない場合はundefined
+ */
 export type RuleEvaluation<
   Options extends RuleOptions = RuleOptions,
   Condition extends RuleEvaluationCondition = RuleEvaluationCondition,
@@ -120,14 +191,28 @@ export type RuleEvaluation<
   condition: Condition,
 ) => RuleResult[] | undefined;
 
+/**
+ * アクセシビリティルールの定義
+ *
+ * 各ルールはこのインターフェースを実装したオブジェクトとして定義され、
+ * `Rules` に登録される。`tagNames`・`roles`・`selectors` は評価対象の
+ * 事前フィルタリング（`isRuleTargetElement`）に使われ、いずれも未指定の
+ * 場合はすべての要素が対象になる
+ */
 export type RuleObject<
   Options extends RuleOptions = RuleOptions,
   Condition extends RuleEvaluationCondition = RuleEvaluationCondition,
 > = {
+  /** ルールの識別名（評価結果の `ruleName` に設定される） */
   ruleName: string;
+  /** ルールの評価関数 */
   evaluate: RuleEvaluation<Options, Condition>;
+  /** ルールのデフォルトオプション */
   defaultOptions: Options;
+  /** 評価対象とするタグ名の一覧 */
   tagNames?: readonly string[];
+  /** 評価対象とするロールの一覧 */
   roles?: readonly string[];
+  /** 評価対象とするCSSセレクタの一覧 */
   selectors?: readonly string[];
 };

--- a/packages/rules/src/utils.ts
+++ b/packages/rules/src/utils.ts
@@ -1,6 +1,18 @@
 import { getKnownRole } from "@a11y-visualizer/dom-utils";
 import type { RuleObject, RuleResult } from "./type";
 
+/**
+ * 要素がルールの評価対象かどうかを判定する
+ *
+ * ルールに定義された `tagNames`・`roles`・`selectors` のいずれかにマッチ
+ * するかで判定する。いずれも定義されていないルールはすべての要素が対象。
+ * `evaluate` を呼び出す前の事前フィルタリングとして使う
+ *
+ * @param element - 対象の要素
+ * @param ruleObject - 判定するルール
+ * @param role - 要素のロール（計算済みの場合に渡すと再計算を省略できる）
+ * @returns ルールの評価対象の場合はtrue
+ */
 export const isRuleTargetElement = (
   element: Element,
   ruleObject: RuleObject,
@@ -16,6 +28,15 @@ export const isRuleTargetElement = (
   return false;
 };
 
+/**
+ * 評価結果を識別する文字列を生成する
+ *
+ * 同じ要素に対する評価結果の一覧を表示する際の重複判定や、
+ * Reactのkeyとして使う
+ *
+ * @param result - 評価結果
+ * @returns 評価結果の種類と内容から生成した識別文字列
+ */
 export const getRuleResultIdentifier = (result: RuleResult): string => {
   switch (result.type) {
     case "error":

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -22,12 +22,31 @@ type Cell = {
   headerScope: Scope;
 };
 
+/**
+ * テーブルの構造を解析し、セルの位置関係やヘッダーの対応を扱えるようにするクラス
+ *
+ * table要素またはtable/grid/treegridロールを持つ要素を、HTML仕様の
+ * テーブルモデルに準じて解析する。colspan/rowspanやaria-colindex/
+ * aria-rowindexなどのARIA属性も考慮して、各セルの座標・サイズ・
+ * ヘッダーとしてのスコープを求める。
+ *
+ * 拡張機能では、テーブル系ルール（table-header・table-position・table-size）が
+ * セルに対応するヘッダーやセルの位置・テーブルの大きさを表示するために使う。
+ * 解析コストが高いため、同じテーブルへの複数セルの評価ではインスタンスを
+ * 使い回すことが想定されている（`RuleEvaluationCondition` の `tables`）
+ */
 export class Table {
+  /** 解析対象のテーブル要素 */
   element: Element;
+  /** 行グループ（thead/tbody/tfootまたはrowgroupロール）の一覧 */
   rowGroups: RowGroup[];
+  /** 列グループ（colgroup要素）の一覧 */
   colGroups: ColGroup[];
+  /** 行ごとのセルの二次元配列 */
   cells: Cell[][];
+  /** テーブルの行数（aria-rowcountがあればその値） */
   rowCount: number;
+  /** テーブルの列数（aria-colcountがあればその値） */
   colCount: number;
 
   constructor(table: Element) {
@@ -211,6 +230,12 @@ export class Table {
     this.colCount = colCount;
   }
 
+  /**
+   * セル要素に対応するセル情報（座標・サイズ・ヘッダーのスコープ）を取得する
+   *
+   * @param el - テーブル内のセル要素
+   * @returns セル情報、テーブル内に見つからない場合はnull
+   */
   getCell = (el: Element): Cell | null => {
     const cell = this.cells
       .map((row) => row.find((cell) => cell.element === el))
@@ -218,6 +243,16 @@ export class Table {
     return cell ? cell[0] : null;
   };
 
+  /**
+   * セルに対応するヘッダーセル要素の一覧を取得する
+   *
+   * headers属性があればその参照先を、なければHTML仕様のヘッダー割り当て
+   * アルゴリズムに準じて行・列・行グループ・列グループのヘッダーを集める。
+   * 空のセルと自分自身は除外される
+   *
+   * @param cell - 対象のセル（{@link getCell} で取得したもの）
+   * @returns ヘッダーセル要素の配列（重複なし）
+   */
   getHeaderElements = (cell: Cell): Element[] => {
     const tagName = cell.element.tagName.toLowerCase();
     return (
@@ -238,6 +273,15 @@ export class Table {
     }, [] as Element[]);
   };
 
+  /**
+   * 指定した座標（スロット）を占めるセルの一覧を取得する
+   *
+   * colspan/rowspanで広がっているセルも、その範囲に座標が含まれれば返される
+   *
+   * @param x - 列位置（0始まり）
+   * @param y - 行位置（0始まり）
+   * @returns 座標を占めるセルの配列
+   */
   getSlotCells = (x: number, y: number): Cell[] => {
     return this.cells
       .map((row) =>
@@ -252,6 +296,15 @@ export class Table {
       .filter((cell): cell is Cell => !!cell);
   };
 
+  /**
+   * セルが列ヘッダーとして働くかどうかを判定する
+   *
+   * scope属性がcolの場合に加え、scopeがautoの場合はHTML仕様の
+   * ヘッダー割り当てアルゴリズムに準じて周囲のセルから推定する
+   *
+   * @param cell - 対象のセル
+   * @returns 列ヘッダーの場合はtrue
+   */
   isColHeader = (cell: Cell): boolean => {
     const { headerScope } = cell;
     return (
@@ -268,6 +321,15 @@ export class Table {
     );
   };
 
+  /**
+   * セルが行ヘッダーとして働くかどうかを判定する
+   *
+   * scope属性がrowの場合に加え、scopeがautoの場合はHTML仕様の
+   * ヘッダー割り当てアルゴリズムに準じて周囲のセルから推定する
+   *
+   * @param cell - 対象のセル
+   * @returns 行ヘッダーの場合はtrue
+   */
   isRowHeader = (cell: Cell): boolean => {
     const { headerScope } = cell;
     return (
@@ -285,6 +347,14 @@ export class Table {
     );
   };
 
+  /**
+   * セルの行ヘッダー（同じ行の左方向にあるヘッダーセル）の要素を取得する
+   *
+   * 通常は {@link getHeaderElements} を使う。空のセルと自分自身は除外される
+   *
+   * @param cell - 対象のセル
+   * @returns 行ヘッダーの要素の配列
+   */
   getRowHeaderElements = (cell: Cell): Element[] => {
     const { positionY, sizeY, positionX, element } = cell;
     const headers: Element[] = [];
@@ -325,6 +395,14 @@ export class Table {
     return headers.filter((el) => el !== element && !isEmptyCellElement(el));
   };
 
+  /**
+   * セルが属する行グループのヘッダー（scope="rowgroup"のセル）の要素を取得する
+   *
+   * 通常は {@link getHeaderElements} を使う。空のセルと自分自身は除外される
+   *
+   * @param cell - 対象のセル
+   * @returns 行グループヘッダーの要素の配列
+   */
   getRowGroupHeaderElements = (cell: Cell): Element[] => {
     const { positionY, positionX, sizeX, sizeY, element } = cell;
     const rowGroup = this.rowGroups.find(
@@ -350,6 +428,14 @@ export class Table {
       .filter((el) => el !== element && !isEmptyCellElement(el));
   };
 
+  /**
+   * セルの列ヘッダー（同じ列の上方向にあるヘッダーセル）の要素を取得する
+   *
+   * 通常は {@link getHeaderElements} を使う。空のセルと自分自身は除外される
+   *
+   * @param cell - 対象のセル
+   * @returns 列ヘッダーの要素の配列
+   */
   getColHeaderElements = (cell: Cell): Element[] => {
     const { positionY, positionX, sizeX, element } = cell;
     const headers: Element[] = [];
@@ -391,6 +477,14 @@ export class Table {
     return headers.filter((el) => el !== element && !isEmptyCellElement(el));
   };
 
+  /**
+   * セルが属する列グループのヘッダー（scope="colgroup"のセル）の要素を取得する
+   *
+   * 通常は {@link getHeaderElements} を使う。空のセルと自分自身は除外される
+   *
+   * @param cell - 対象のセル
+   * @returns 列グループヘッダーの要素の配列
+   */
   getColGroupHeaderElements = (cell: Cell): Element[] => {
     const { positionY, positionX, sizeX, sizeY, element } = cell;
     const colGroup = this.colGroups.find(
@@ -416,6 +510,15 @@ export class Table {
       .filter((el) => el !== element && !isEmptyCellElement(el));
   };
 
+  /**
+   * セルのheaders属性が参照するヘッダーセル要素を取得する
+   *
+   * th/td要素のみが対象。通常は {@link getHeaderElements} を使う。
+   * 空のセルと自分自身は除外される
+   *
+   * @param cell - 対象のセル
+   * @returns headers属性で参照されているセル要素の配列
+   */
   getAttributeHeaderElements = (cell: Cell): Element[] => {
     const { element } = cell;
     const tagName = element.tagName.toLowerCase();
@@ -436,6 +539,16 @@ export class Table {
   };
 }
 
+/**
+ * テーブル要素から行要素（tr要素またはrowロールの要素）の一覧を取得する
+ *
+ * table要素またはtable/grid/treegridロールの要素が対象。行グループや
+ * presentationロールの要素の中の行も収集する。tfoot要素はHTML仕様に
+ * 準じて最後に並べる
+ *
+ * @param el - テーブル要素
+ * @returns 行要素の配列（テーブルでない要素の場合は空配列）
+ */
 export const getRowElements = (el: Element): Element[] => {
   const tagName = el.tagName.toLowerCase();
   const role = getKnownRole(el);
@@ -481,6 +594,16 @@ const getRowElementsInElement = (
   return [];
 };
 
+/**
+ * テーブル要素から行グループ要素（thead/tbody/tfoot要素または
+ * rowgroupロールの要素）の一覧を取得する
+ *
+ * table要素またはtable/grid/treegridロールの要素が対象。tfoot要素は
+ * HTML仕様に準じて最後に並べる
+ *
+ * @param el - テーブル要素
+ * @returns 行グループ要素の配列（テーブルでない要素の場合は空配列）
+ */
 export const getRowGroupElements = (el: Element): Element[] => {
   const tagName = el.tagName.toLowerCase();
   const role = getKnownRole(el);
@@ -529,6 +652,16 @@ const getRowGroupElementsInElement = (
   return [];
 };
 
+/**
+ * 行要素からセル要素の一覧を取得する
+ *
+ * tr要素の場合はth/td要素を、rowロールの要素の場合はcell/gridcell/
+ * columnheader/rowheaderロールの子要素を収集する。presentationロールの
+ * 要素は透過して中のセルを収集する
+ *
+ * @param el - 行要素（{@link getRowElements} で取得したもの）
+ * @returns セル要素の配列（行でない要素の場合は空配列）
+ */
 export const getCellElements = (el: Element): Element[] => {
   const tagName = el.tagName.toLowerCase();
   const role = getKnownRole(el);
@@ -556,5 +689,13 @@ export const getCellElements = (el: Element): Element[] => {
   return [];
 };
 
+/**
+ * セル要素が空（子要素がなく、テキストも空白のみ）かどうかを判定する
+ *
+ * 空のセルはヘッダーの割り当て対象から除外される
+ *
+ * @param el - 対象のセル要素
+ * @returns 空のセルの場合はtrue
+ */
 export const isEmptyCellElement = (el: Element): boolean =>
   el.children.length === 0 && (!el.textContent || el.textContent.trim() === "");


### PR DESCRIPTION
Document all exports of @a11y-visualizer/dom-utils, rules, and table packages, describing what each export is and when to use it based on how they are used from the browser extension and other packages.

Also rename getComputedImplictRole to getComputedImplicitRole.