### PR TITLE
fix: aria-validationのARIA属性検証をWAI-ARIA 1.2に整合

### DIFF
--- a/.changeset/aria-validation-aria12-fixes.md
+++ b/.changeset/aria-validation-aria12-fixes.md
@@ -1,0 +1,11 @@
+---
+"@a11y-visualizer/rules": patch
+---
+
+Align ARIA attribute validation with WAI-ARIA 1.2 to reduce false positives:
+
+- `aria-modal` is now accepted on `alertdialog` (in addition to `dialog`).
+- `aria-valuemin` / `aria-valuemax` / `aria-valuenow` / `aria-valuetext` are now accepted on `meter`.
+- `aria-colcount` / `aria-rowcount` / `aria-setsize` now accept `-1` (unknown total).
+- `aria-activedescendant` is now accepted on `toolbar` and `spinbutton`.
+- `aria-haspopup` and `aria-errormessage` are validated as non-global attributes, so misuse on unsupported roles is now reported.

--- a/packages/rules/src/aria-validation/ariaSpec.ts
+++ b/packages/rules/src/aria-validation/ariaSpec.ts
@@ -179,7 +179,9 @@ export const ARIA_ATTRIBUTE_ROLES: Record<AriaAttribute, string[] | "all"> = {
     "rowheader",
     "searchbox",
     "select",
+    "spinbutton",
     "tablist",
+    "toolbar",
     "tree",
     "treegrid",
     "treeitem",
@@ -246,7 +248,24 @@ export const ARIA_ATTRIBUTE_ROLES: Record<AriaAttribute, string[] | "all"> = {
     "treeitem",
   ],
   "aria-dropeffect": "all", // global (deprecated)
-  "aria-errormessage": "all", // global
+  // Not global in ARIA 1.2; supported on the same roles as aria-invalid
+  "aria-errormessage": [
+    "application",
+    "checkbox",
+    "combobox",
+    "gridcell",
+    "listbox",
+    "radiogroup",
+    "slider",
+    "spinbutton",
+    "textbox",
+    "tree",
+    "columnheader",
+    "rowheader",
+    "searchbox",
+    "switch",
+    "treegrid",
+  ],
   "aria-expanded": [
     "application",
     "button",
@@ -267,7 +286,24 @@ export const ARIA_ATTRIBUTE_ROLES: Record<AriaAttribute, string[] | "all"> = {
   ],
   "aria-flowto": "all", // global
   "aria-grabbed": "all", // global (deprecated)
-  "aria-haspopup": "all", // global
+  // Not global in ARIA 1.2; supported on widget-like roles that can trigger popups
+  "aria-haspopup": [
+    "application",
+    "button",
+    "columnheader",
+    "combobox",
+    "gridcell",
+    "link",
+    "menuitem",
+    "menuitemcheckbox",
+    "menuitemradio",
+    "rowheader",
+    "searchbox",
+    "slider",
+    "tab",
+    "textbox",
+    "treeitem",
+  ],
   "aria-hidden": "all", // global
   "aria-invalid": [
     "application",
@@ -291,7 +327,7 @@ export const ARIA_ATTRIBUTE_ROLES: Record<AriaAttribute, string[] | "all"> = {
   "aria-labelledby": "all", // global
   "aria-level": ["heading", "listitem", "row", "treeitem"],
   "aria-live": "all", // global
-  "aria-modal": ["dialog"],
+  "aria-modal": ["dialog", "alertdialog"],
   "aria-multiline": ["textbox", "searchbox"],
   "aria-multiselectable": ["grid", "listbox", "tablist", "tree", "treegrid"],
   "aria-orientation": [
@@ -383,6 +419,7 @@ export const ARIA_ATTRIBUTE_ROLES: Record<AriaAttribute, string[] | "all"> = {
   ],
   "aria-sort": ["columnheader", "rowheader"],
   "aria-valuemax": [
+    "meter",
     "progressbar",
     "scrollbar",
     "separator",
@@ -390,6 +427,7 @@ export const ARIA_ATTRIBUTE_ROLES: Record<AriaAttribute, string[] | "all"> = {
     "spinbutton",
   ],
   "aria-valuemin": [
+    "meter",
     "progressbar",
     "scrollbar",
     "separator",
@@ -397,6 +435,7 @@ export const ARIA_ATTRIBUTE_ROLES: Record<AriaAttribute, string[] | "all"> = {
     "spinbutton",
   ],
   "aria-valuenow": [
+    "meter",
     "progressbar",
     "scrollbar",
     "separator",
@@ -404,6 +443,7 @@ export const ARIA_ATTRIBUTE_ROLES: Record<AriaAttribute, string[] | "all"> = {
     "spinbutton",
   ],
   "aria-valuetext": [
+    "meter",
     "progressbar",
     "scrollbar",
     "separator",
@@ -417,6 +457,16 @@ export const ARIA_ATTRIBUTE_ROLES: Record<AriaAttribute, string[] | "all"> = {
 // ============================================================================
 
 /**
+ * Integer attributes whose value may be -1 to indicate that the total is unknown.
+ * (ARIA 1.2: aria-colcount / aria-rowcount / aria-setsize)
+ */
+const INTEGER_ATTRIBUTES_ALLOWING_UNKNOWN: AriaAttribute[] = [
+  "aria-colcount",
+  "aria-rowcount",
+  "aria-setsize",
+];
+
+/**
  * Validates the value of any ARIA attribute.
  */
 export const validateAriaAttributeValue = (
@@ -426,8 +476,16 @@ export const validateAriaAttributeValue = (
   const validValues = ARIA_ATTRIBUTE_VALUES[attribute];
 
   if (validValues === "integer") {
-    const num = parseInt(value.trim(), 10);
-    return !Number.isNaN(num) && num.toString() === value.trim() && num >= 1;
+    const trimmed = value.trim();
+    const num = parseInt(trimmed, 10);
+    if (Number.isNaN(num) || num.toString() !== trimmed) {
+      return false;
+    }
+    // -1 is a valid "unknown total" value for count / setsize attributes
+    if (num === -1 && INTEGER_ATTRIBUTES_ALLOWING_UNKNOWN.includes(attribute)) {
+      return true;
+    }
+    return num >= 1;
   }
 
   if (validValues === "number") {

--- a/packages/rules/src/aria-validation/index.test.ts
+++ b/packages/rules/src/aria-validation/index.test.ts
@@ -343,4 +343,224 @@ describe("AriaValidation", () => {
       ruleName: "aria-validation",
     });
   });
+
+  // aria-modal is valid on both dialog and alertdialog (ARIA 1.2)
+  test("validates aria-modal on alertdialog role", () => {
+    document.body.innerHTML = `<div role="alertdialog" aria-modal="true">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("validates aria-modal on dialog role", () => {
+    document.body.innerHTML = `<div role="dialog" aria-modal="true">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  // meter is a range subclass, aria-value* attributes are valid (ARIA 1.2)
+  test("validates aria-valuenow on meter role", () => {
+    document.body.innerHTML = `<div role="meter" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("validates aria-valuetext on meter role", () => {
+    document.body.innerHTML = `<div role="meter" aria-valuenow="50" aria-valuetext="50 percent">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  // -1 is a valid "unknown total" value for count/setsize attributes (ARIA 1.2)
+  test("validates aria-colcount with -1 (unknown)", () => {
+    document.body.innerHTML = `<div role="grid" aria-colcount="-1">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("validates aria-rowcount with -1 (unknown)", () => {
+    document.body.innerHTML = `<div role="grid" aria-rowcount="-1">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("validates aria-setsize with -1 (unknown)", () => {
+    document.body.innerHTML = `<div role="listitem" aria-setsize="-1">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("rejects aria-colindex with -1 (must be >= 1)", () => {
+    document.body.innerHTML = `<div role="row" aria-colindex="-1">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toEqual({
+      type: "error",
+      message: "Invalid WAI-ARIA attribute value: {{attribute}}",
+      messageParams: { attribute: "aria-colindex" },
+      ruleName: "aria-validation",
+    });
+  });
+
+  // aria-activedescendant is valid on toolbar and spinbutton (ARIA 1.2)
+  test("validates aria-activedescendant on toolbar role", () => {
+    document.body.innerHTML = `<div role="toolbar" aria-activedescendant="item1">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("validates aria-activedescendant on spinbutton role", () => {
+    document.body.innerHTML = `<div role="spinbutton" aria-activedescendant="item1">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  // aria-haspopup is non-global in ARIA 1.2 (only widget-like roles)
+  test("validates aria-haspopup on button role", () => {
+    document.body.innerHTML = `<div role="button" aria-haspopup="menu">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("reports error for aria-haspopup on non-supported role", () => {
+    document.body.innerHTML = `<div role="list" aria-haspopup="menu">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toEqual({
+      type: "error",
+      message: "Invalid role for WAI-ARIA attribute: {{attribute}}",
+      messageParams: { attribute: "aria-haspopup" },
+      ruleName: "aria-validation",
+    });
+  });
+
+  // aria-errormessage is non-global in ARIA 1.2 (same roles as aria-invalid)
+  test("validates aria-errormessage on textbox role", () => {
+    document.body.innerHTML = `<div role="textbox" aria-errormessage="err1">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("reports error for aria-errormessage on non-supported role", () => {
+    document.body.innerHTML = `<div role="button" aria-errormessage="err1">Content</div>`;
+    const element = document.querySelector("div");
+    if (!element) {
+      throw new Error("Element not found");
+    }
+    const result = AriaValidation.evaluate(
+      element,
+      AriaValidation.defaultOptions,
+      {},
+    );
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toEqual({
+      type: "error",
+      message: "Invalid role for WAI-ARIA attribute: {{attribute}}",
+      messageParams: { attribute: "aria-errormessage" },
+      ruleName: "aria-validation",
+    });
+  });
 });


### PR DESCRIPTION
## 概要

`aria-validation` ルールのARIA属性検証をWAI-ARIA 1.2に整合させ、正当なマークアップの誤検出(false positive)を減らします。あわせて、これまで見逃していた非グローバル属性の誤用も検出できるようにします。

## 変更内容(`packages/rules/src/aria-validation/ariaSpec.ts`)

- **`aria-modal`**: 許可ロールに `alertdialog` を追加(`dialog` に加えて)。`role="alertdialog" aria-modal="true"` はAPGの標準パターンだが、これまでエラーになっていた。
- **`aria-valuemin` / `aria-valuemax` / `aria-valuenow` / `aria-valuetext`**: 許可ロールに `meter` を追加。ARIA 1.2でmeterはrangeサブクラスで、`role="meter"` には `aria-valuenow` が必須。
- **`aria-colcount` / `aria-rowcount` / `aria-setsize`**: `-1`(総数不明)を正当な値として許可。他のinteger属性は従来どおり `>= 1`。
- **`aria-activedescendant`**: 許可ロールに `toolbar` / `spinbutton` を追加。
- **`aria-haspopup` / `aria-errormessage`**: ARIA 1.2で非グローバルなため、`"all"` から特定ロールに限定。`errormessage` は `aria-invalid` と同じロール集合、`haspopup` はウィジェット系ロール(`aria-query` のARIA 1.2データで裏取り)。**この項目のみ検証を厳格化する方向の挙動変更**で、非対応ロールでの誤用が新たにエラー表示される。

## テスト

- `index.test.ts` に境界ケースを含む10件を追加(正当なマークアップが通ること、`-1` が `aria-colindex` では不正なこと、haspopup/errormessage が非対応ロールでエラーになること等)
- `packages/rules` 全体: 1051 passed / 1 skipped、`pnpm lint-fix` clean
- `ARIA_ATTRIBUTE_ROLES` を参照する `aria-state` ルールは今回変更した属性を扱っていないため影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)