### PR TITLE
fix: 非表示から表示になったalertを検出できるようにする

### DIFF
--- a/.changeset/live-region-hidden-alert.md
+++ b/.changeset/live-region-hidden-alert.md
@@ -1,0 +1,5 @@
+---
+"@a11y-visualizer/browser-extension": patch
+---
+
+Announce alerts that become visible after being hidden. Previously, a `role="alert"` element that was hidden (via `display:none`, the `hidden` attribute, `aria-hidden`, `inert`, or `aria-busy`) when first scanned would never be announced even after it became visible. Such alerts are now re-checked on subsequent scans and announced once they become renderable.

--- a/apps/browser_extension/entrypoints/all-frames.content/hooks/createAlertTracker.test.ts
+++ b/apps/browser_extension/entrypoints/all-frames.content/hooks/createAlertTracker.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAlertTracker } from "./createAlertTracker";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+const createAlert = (): Element => {
+  const el = document.createElement("div");
+  el.setAttribute("role", "alert");
+  el.textContent = "alert";
+  document.body.appendChild(el);
+  return el;
+};
+
+describe("createAlertTracker", () => {
+  it("renderableなalertは即座にannounceされる", () => {
+    const tracker = createAlertTracker();
+    const announce = vi.fn();
+    const el = createAlert();
+
+    tracker.handle(el, { isRenderable: () => true, announce });
+
+    expect(announce).toHaveBeenCalledTimes(1);
+    expect(announce).toHaveBeenCalledWith(el);
+  });
+
+  it("同じalertを二度announceしない", () => {
+    const tracker = createAlertTracker();
+    const announce = vi.fn();
+    const el = createAlert();
+    const options = { isRenderable: () => true, announce };
+
+    tracker.handle(el, options);
+    tracker.handle(el, options);
+
+    expect(announce).toHaveBeenCalledTimes(1);
+  });
+
+  it("renderableでないalertはannounceされずpendingになる", () => {
+    const tracker = createAlertTracker();
+    const announce = vi.fn();
+    const el = createAlert();
+
+    tracker.handle(el, { isRenderable: () => false, announce });
+
+    expect(announce).not.toHaveBeenCalled();
+  });
+
+  it("非表示から表示になったalertは再チェックでannounceされる", () => {
+    const tracker = createAlertTracker();
+    const announce = vi.fn();
+    const el = createAlert();
+    let renderable = false;
+    const options = {
+      isRenderable: () => renderable,
+      announce,
+    };
+
+    // 初回スキャン時は非表示なので見送られる
+    tracker.handle(el, options);
+    expect(announce).not.toHaveBeenCalled();
+
+    // 表示に切り替わってから再チェックするとannounceされる
+    renderable = true;
+    tracker.recheckPending(options);
+    expect(announce).toHaveBeenCalledTimes(1);
+    expect(announce).toHaveBeenCalledWith(el);
+  });
+
+  it("再チェックで一度announceしたalertは再度announceしない", () => {
+    const tracker = createAlertTracker();
+    const announce = vi.fn();
+    const el = createAlert();
+    let renderable = false;
+    const options = {
+      isRenderable: () => renderable,
+      announce,
+    };
+
+    tracker.handle(el, options);
+    renderable = true;
+    tracker.recheckPending(options);
+    tracker.recheckPending(options);
+
+    expect(announce).toHaveBeenCalledTimes(1);
+  });
+
+  it("非表示のまま再チェックしてもannounceしない", () => {
+    const tracker = createAlertTracker();
+    const announce = vi.fn();
+    const el = createAlert();
+    const options = { isRenderable: () => false, announce };
+
+    tracker.handle(el, options);
+    tracker.recheckPending(options);
+    tracker.recheckPending(options);
+
+    expect(announce).not.toHaveBeenCalled();
+  });
+
+  it("DOMから取り除かれたpending alertは再チェックで破棄される", () => {
+    const tracker = createAlertTracker();
+    const announce = vi.fn();
+    const el = createAlert();
+    let renderable = false;
+    const options = {
+      isRenderable: () => renderable,
+      announce,
+    };
+
+    tracker.handle(el, options);
+    // pendingのままDOMから取り除く
+    el.remove();
+
+    // 破棄されるので、表示可能に戻してもannounceされない
+    renderable = true;
+    tracker.recheckPending(options);
+    expect(announce).not.toHaveBeenCalled();
+
+    // 破棄済みなので再度追加・表示してもannounceされない
+    // (同一要素は破棄されたが、handleで明示的に扱えば再登録される)
+    document.body.appendChild(el);
+    tracker.recheckPending(options);
+    expect(announce).not.toHaveBeenCalled();
+  });
+
+  it("複数のpending alertをそれぞれ独立に扱う", () => {
+    const tracker = createAlertTracker();
+    const announce = vi.fn();
+    const el1 = createAlert();
+    const el2 = createAlert();
+    const renderable = new Set<Element>();
+    const options = {
+      isRenderable: (el: Element) => renderable.has(el),
+      announce,
+    };
+
+    tracker.handle(el1, options);
+    tracker.handle(el2, options);
+    expect(announce).not.toHaveBeenCalled();
+
+    // el1のみ表示可能にする
+    renderable.add(el1);
+    tracker.recheckPending(options);
+    expect(announce).toHaveBeenCalledTimes(1);
+    expect(announce).toHaveBeenCalledWith(el1);
+
+    // el2も表示可能にする
+    renderable.add(el2);
+    tracker.recheckPending(options);
+    expect(announce).toHaveBeenCalledTimes(2);
+    expect(announce).toHaveBeenCalledWith(el2);
+  });
+});

--- a/apps/browser_extension/entrypoints/all-frames.content/hooks/createAlertTracker.test.ts
+++ b/apps/browser_extension/entrypoints/all-frames.content/hooks/createAlertTracker.test.ts
@@ -86,6 +86,32 @@ describe("createAlertTracker", () => {
     expect(announce).toHaveBeenCalledTimes(1);
   });
 
+  it("一度表示されたalertを非表示にして再度表示すると再announceされる", () => {
+    const tracker = createAlertTracker();
+    const announce = vi.fn();
+    const el = createAlert();
+    let renderable = true;
+    const options = {
+      isRenderable: () => renderable,
+      announce,
+    };
+
+    // 初回表示でannounceされる
+    tracker.handle(el, options);
+    expect(announce).toHaveBeenCalledTimes(1);
+
+    // 非表示にする（display:noneやhidden属性などを想定）
+    renderable = false;
+    tracker.recheckPending(options);
+    expect(announce).toHaveBeenCalledTimes(1);
+
+    // 再度表示すると再announceされる
+    renderable = true;
+    tracker.recheckPending(options);
+    expect(announce).toHaveBeenCalledTimes(2);
+    expect(announce).toHaveBeenLastCalledWith(el);
+  });
+
   it("非表示のまま再チェックしてもannounceしない", () => {
     const tracker = createAlertTracker();
     const announce = vi.fn();

--- a/apps/browser_extension/entrypoints/all-frames.content/hooks/createAlertTracker.ts
+++ b/apps/browser_extension/entrypoints/all-frames.content/hooks/createAlertTracker.ts
@@ -4,52 +4,61 @@ export type AlertHandlerOptions = {
    * suppressed by a modal, etc.).
    */
   isRenderable: (element: Element) => boolean;
-  /** Announce the alert. Called at most once per element. */
+  /** Announce the alert. Called at most once per renderable transition. */
   announce: (element: Element) => void;
 };
 
 export type AlertTracker = {
   /**
    * Evaluate an alert element. Announces it when it is renderable and has not
-   * been announced yet. When it is not renderable yet, the element is kept as
-   * pending so it can be re-evaluated later via {@link recheckPending}.
+   * been announced since it last became renderable. When it is not renderable
+   * yet, the element is kept tracked so it can be re-evaluated later via
+   * {@link recheckPending}.
    */
   handle: (element: Element, options: AlertHandlerOptions) => void;
   /**
-   * Re-evaluate all pending alerts (those previously skipped because they were
-   * not renderable). Attribute/style changes such as toggling `display:none`
-   * do not reach a childList/characterData observer, so visibility must be
-   * re-checked on each scan. Disconnected elements are discarded.
+   * Re-evaluate every tracked alert. Attribute/style changes such as toggling
+   * `display:none` do not reach a childList/characterData observer, so
+   * visibility must be re-checked on each scan. An alert that has become
+   * non-renderable has its announced state reset so it will be announced again
+   * once it becomes renderable — mirroring screen readers, which re-announce a
+   * `role="alert"` element each time it (re)appears. Disconnected elements are
+   * discarded.
    */
   recheckPending: (options: AlertHandlerOptions) => void;
 };
 
 export const createAlertTracker = (): AlertTracker => {
-  const processed = new WeakSet<Element>();
-  const pending = new Set<Element>();
+  // All alert elements currently being tracked. The boolean records whether the
+  // alert has already been announced while in its current renderable state.
+  // When an alert becomes non-renderable, the flag is reset to `false` so a
+  // later hidden→visible transition re-announces it.
+  const tracked = new Map<Element, boolean>();
+
+  const evaluate = (element: Element, options: AlertHandlerOptions) => {
+    if (options.isRenderable(element)) {
+      if (!tracked.get(element)) {
+        tracked.set(element, true);
+        options.announce(element);
+      }
+      return;
+    }
+    // Not renderable yet: keep watching so it can be announced once it becomes
+    // renderable, and reset the announced flag for hidden→visible transitions.
+    tracked.set(element, false);
+  };
 
   const handle = (element: Element, options: AlertHandlerOptions) => {
-    if (processed.has(element)) {
-      pending.delete(element);
-      return;
-    }
-    if (!options.isRenderable(element)) {
-      // Keep watching so it can be announced once it becomes renderable.
-      pending.add(element);
-      return;
-    }
-    processed.add(element);
-    pending.delete(element);
-    options.announce(element);
+    evaluate(element, options);
   };
 
   const recheckPending = (options: AlertHandlerOptions) => {
-    pending.forEach((element) => {
+    tracked.forEach((_announced, element) => {
       if (!element.isConnected) {
-        pending.delete(element);
+        tracked.delete(element);
         return;
       }
-      handle(element, options);
+      evaluate(element, options);
     });
   };
 

--- a/apps/browser_extension/entrypoints/all-frames.content/hooks/createAlertTracker.ts
+++ b/apps/browser_extension/entrypoints/all-frames.content/hooks/createAlertTracker.ts
@@ -1,0 +1,57 @@
+export type AlertHandlerOptions = {
+  /**
+   * Whether the alert can be announced right now (visible, not busy, not
+   * suppressed by a modal, etc.).
+   */
+  isRenderable: (element: Element) => boolean;
+  /** Announce the alert. Called at most once per element. */
+  announce: (element: Element) => void;
+};
+
+export type AlertTracker = {
+  /**
+   * Evaluate an alert element. Announces it when it is renderable and has not
+   * been announced yet. When it is not renderable yet, the element is kept as
+   * pending so it can be re-evaluated later via {@link recheckPending}.
+   */
+  handle: (element: Element, options: AlertHandlerOptions) => void;
+  /**
+   * Re-evaluate all pending alerts (those previously skipped because they were
+   * not renderable). Attribute/style changes such as toggling `display:none`
+   * do not reach a childList/characterData observer, so visibility must be
+   * re-checked on each scan. Disconnected elements are discarded.
+   */
+  recheckPending: (options: AlertHandlerOptions) => void;
+};
+
+export const createAlertTracker = (): AlertTracker => {
+  const processed = new WeakSet<Element>();
+  const pending = new Set<Element>();
+
+  const handle = (element: Element, options: AlertHandlerOptions) => {
+    if (processed.has(element)) {
+      pending.delete(element);
+      return;
+    }
+    if (!options.isRenderable(element)) {
+      // Keep watching so it can be announced once it becomes renderable.
+      pending.add(element);
+      return;
+    }
+    processed.add(element);
+    pending.delete(element);
+    options.announce(element);
+  };
+
+  const recheckPending = (options: AlertHandlerOptions) => {
+    pending.forEach((element) => {
+      if (!element.isConnected) {
+        pending.delete(element);
+        return;
+      }
+      handle(element, options);
+    });
+  };
+
+  return { handle, recheckPending };
+};

--- a/apps/browser_extension/entrypoints/all-frames.content/hooks/useLiveRegionLocal.ts
+++ b/apps/browser_extension/entrypoints/all-frames.content/hooks/useLiveRegionLocal.ts
@@ -11,6 +11,11 @@ import { SettingsContext } from "../../content/contexts/SettingsContext";
 import { isAnnouncementSuppressedByModal } from "../../content/dom/detectModals";
 import { createLiveRegionMessage } from "../../content/shared/protocol";
 import type { AnnouncementItem, LiveLevel } from "../../content/types";
+import {
+  type AlertHandlerOptions,
+  type AlertTracker,
+  createAlertTracker,
+} from "./createAlertTracker";
 
 const LIVEREGION_SELECTOR =
   "output, [role~='status'], [role~='alert'], [role~='log'], [aria-live]:not([aria-live='off'])";
@@ -75,7 +80,14 @@ export const useLiveRegionLocal = ({
   } = React.useContext(SettingsContext);
   const liveRegionsRef = React.useRef<Element[]>([]);
   const liveRegionObserverRef = React.useRef<MutationObserver | null>(null);
-  const processedAlertsRef = React.useRef<WeakSet<Element>>(new WeakSet());
+  // Tracks which alerts have already been announced and which ones were
+  // skipped because they were not renderable yet (hidden, aria-hidden, inert,
+  // busy, or suppressed by a modal). The latter are re-checked on every scan
+  // so they can be announced once they become visible.
+  const alertTrackerRef = React.useRef<AlertTracker | null>(null);
+  if (!alertTrackerRef.current) {
+    alertTrackerRef.current = createAlertTracker();
+  }
 
   // Self-mode state (for legacy frames)
   const [announcements, setAnnouncements] = React.useState<AnnouncementItem[]>(
@@ -135,51 +147,49 @@ export const useLiveRegionLocal = ({
     setPausedAnnouncements((prev) => (prev.length > 0 ? [] : prev));
   }, []);
 
+  const alertHandlerOptions = React.useMemo<AlertHandlerOptions>(
+    () => ({
+      isRenderable: (alertElement) =>
+        !(
+          isHidden(alertElement) ||
+          isInAriaHidden(alertElement) ||
+          isInInert(alertElement) ||
+          isBusy(alertElement)
+        ) &&
+        !(
+          parentRef.current &&
+          isAnnouncementSuppressedByModal(
+            alertElement,
+            parentRef.current,
+            announceOutOfModal,
+          )
+        ),
+      announce: (alertElement) => {
+        const isAtomic = alertElement.getAttribute("aria-atomic") !== "false";
+
+        let content: string;
+        if (isAtomic) {
+          const name = computeAccessibleName(alertElement);
+          content = [name, alertElement.textContent].filter(Boolean).join(" ");
+        } else {
+          content = alertElement.textContent || "";
+        }
+
+        if (content.trim() === "") {
+          content = computeAccessibleName(alertElement) || "";
+        }
+
+        addAnnouncement(content, "assertive");
+      },
+    }),
+    [addAnnouncement, parentRef, announceOutOfModal],
+  );
+
   const handleAlertAppearance = React.useCallback(
     (alertElement: Element) => {
-      if (processedAlertsRef.current.has(alertElement)) {
-        return;
-      }
-
-      if (
-        isHidden(alertElement) ||
-        isInAriaHidden(alertElement) ||
-        isInInert(alertElement) ||
-        isBusy(alertElement)
-      ) {
-        return;
-      }
-
-      if (
-        parentRef.current &&
-        isAnnouncementSuppressedByModal(
-          alertElement,
-          parentRef.current,
-          announceOutOfModal,
-        )
-      ) {
-        return;
-      }
-
-      processedAlertsRef.current.add(alertElement);
-
-      const isAtomic = alertElement.getAttribute("aria-atomic") !== "false";
-
-      let content: string;
-      if (isAtomic) {
-        const name = computeAccessibleName(alertElement);
-        content = [name, alertElement.textContent].filter(Boolean).join(" ");
-      } else {
-        content = alertElement.textContent || "";
-      }
-
-      if (content.trim() === "") {
-        content = computeAccessibleName(alertElement) || "";
-      }
-
-      addAnnouncement(content, "assertive");
+      alertTrackerRef.current?.handle(alertElement, alertHandlerOptions);
     },
-    [addAnnouncement, parentRef, announceOutOfModal],
+    [alertHandlerOptions],
   );
 
   // Timer management for self-mode announcements
@@ -229,11 +239,19 @@ export const useLiveRegionLocal = ({
     [handleAlertAppearance, renderType],
   );
 
+  // Re-evaluate alerts that were previously skipped while not renderable.
+  // Attribute/style changes (e.g. toggling display:none) do not reach the
+  // childList/characterData observer, so visibility is re-checked on each scan.
+  const recheckPendingAlerts = React.useCallback(() => {
+    alertTrackerRef.current?.recheckPending(alertHandlerOptions);
+  }, [alertHandlerOptions]);
+
   const observeLiveRegion = React.useCallback(
     (el: Element, { firstTime }: { firstTime?: boolean }) => {
       if (!liveRegionObserverRef.current) {
         return;
       }
+      recheckPendingAlerts();
       // Only scan this frame's own live regions (no iframe scanning)
       const shadowRoots = collectShadowRoots(el);
       const liveRegions = [
@@ -252,7 +270,7 @@ export const useLiveRegionLocal = ({
       });
       liveRegionsRef.current = Array.from(liveRegions);
     },
-    [connectLiveRegion],
+    [connectLiveRegion, recheckPendingAlerts],
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
## 概要

`display:none` や `hidden` 属性、`aria-hidden` / `inert` / `aria-busy` などで非表示になっている `role="alert"` 要素が、後から表示状態に切り替わっても通知（アナウンス）されない検出漏れを修正します。

事前にDOMに置いたアラートをCSSや属性のトグルで表示するのはよくあるパターンですが、これまでは初回スキャン時に見送られたまま再評価される経路がなく、表示されても通知されませんでした。

## 変更内容

- 表示不可（hidden / aria-hidden / inert / busy / モーダルによる抑制）で見送ったアラートを pending として追跡し、再スキャン時に可視性を再チェックして表示可能になったら通知するようにしました。`aria-busy` 解除後に通知されなかった問題も同じ経路で解消されます。
- アラートの状態管理ロジック（announce済み / pending の管理と再評価）を純粋なモジュール `createAlertTracker` に切り出し、DOM依存を注入する設計にしてテストを追加しました。

## テスト

- `createAlertTracker.test.ts` を新規追加（非表示→表示での再通知、重複通知の防止、DOMから外れた要素の破棄、複数アラートの独立処理 など）
- 型チェック（`pnpm --filter=@a11y-visualizer/browser-extension compile`）通過
- `pnpm lint-fix` 実行済み（修正なし）
- 拡張機能テスト 446件すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)