### PR TITLE
fix: ライブリージョン検出のaria-atomic/aria-relevant判定を仕様に整合

### DIFF
--- a/.changeset/live-region-atomic-relevant.md
+++ b/.changeset/live-region-atomic-relevant.md
@@ -1,0 +1,8 @@
+---
+"@a11y-visualizer/browser-extension": patch
+---
+
+Improve live region announcement detection to better match ARIA semantics:
+
+- An explicit `aria-atomic="false"` on `role="status"` / `role="alert"` regions is now honored instead of always being treated as atomic.
+- Text changes are only announced when `aria-relevant` includes `text` (or `all`), so regions such as `aria-relevant="additions"` no longer announce text mutations.

--- a/.changeset/live-region-atomic-relevant.md
+++ b/.changeset/live-region-atomic-relevant.md
@@ -5,4 +5,4 @@
 Improve live region announcement detection to better match ARIA semantics:
 
 - An explicit `aria-atomic="false"` on `role="status"` / `role="alert"` regions is now honored instead of always being treated as atomic.
-- Text changes are only announced when `aria-relevant` includes `text` (or `all`), so regions such as `aria-relevant="additions"` no longer announce text mutations.
+- Text changes are only announced when `aria-relevant` includes `text` (or `all`). Because inserting text into a region is a text-node addition (not an element addition), regions such as `aria-relevant="additions"` no longer announce inserted or mutated text, matching NVDA's behavior.

--- a/apps/browser_extension/entrypoints/all-frames.content/hooks/useLiveRegionLocal.ts
+++ b/apps/browser_extension/entrypoints/all-frames.content/hooks/useLiveRegionLocal.ts
@@ -309,10 +309,13 @@ export const useLiveRegionLocal = ({
             role === "alert" || role === "status"
               ? liveRegionNode
               : closestNodeOfSelector(targetNode, "[aria-atomic]");
+          const atomicAttribute = atomicNode?.getAttribute?.("aria-atomic");
+          // alert / status の aria-atomic の暗黙値は true だが、
+          // 明示的な aria-atomic="false" があれば上書きできる
           const isAtomic =
-            role === "alert" ||
-            role === "status" ||
-            atomicNode?.getAttribute?.("aria-atomic") === "true";
+            ((role === "alert" || role === "status") &&
+              atomicAttribute !== "false") ||
+            atomicAttribute === "true";
           if (isAtomic && atomicNode) {
             if (atomicNodes.includes(atomicNode)) {
               return null;
@@ -336,9 +339,11 @@ export const useLiveRegionLocal = ({
             relevant.includes("removals") || relevant.includes("all");
           const additions =
             relevant.includes("additions") || relevant.includes("all");
+          const text = relevant.includes("text") || relevant.includes("all");
 
           const contents = [
-            (r.removedNodes.length === 0 &&
+            (text &&
+              r.removedNodes.length === 0 &&
               r.addedNodes.length === 0 &&
               targetNode?.textContent) ||
               "",

--- a/apps/browser_extension/entrypoints/all-frames.content/hooks/useLiveRegionLocal.ts
+++ b/apps/browser_extension/entrypoints/all-frames.content/hooks/useLiveRegionLocal.ts
@@ -350,9 +350,12 @@ export const useLiveRegionLocal = ({
             ...[...(removals ? r.removedNodes : [])].map(
               (n) => n.textContent || "",
             ),
-            ...[...(additions ? r.addedNodes : [])].map(
-              (n) => n.textContent || "",
-            ),
+            // 要素ノードの追加は additions、テキストノードの追加は text で判定する。
+            // 空の aria-relevant="additions" リージョンへのテキスト挿入は
+            // テキストノードの追加であり、NVDA では通知されないため通知しない。
+            ...[...r.addedNodes]
+              .filter((n) => (n.nodeType === Node.TEXT_NODE ? text : additions))
+              .map((n) => n.textContent || ""),
           ].filter(Boolean);
           return contents.length > 0
             ? { content: contents.join(" "), level }


### PR DESCRIPTION
## 概要

ライブリージョンの読み上げ内容検出ロジック（`useLiveRegionLocal.ts`）を、ARIA の仕様に沿うよう2点修正しました。

## 変更点

### `aria-atomic="false"` の明示指定を尊重

WAI-ARIA 1.2 では `role="status"` / `role="alert"` の `aria-atomic` の暗黙値は `true` ですが、著者が明示的に `aria-atomic="false"` を指定すれば上書きできます。従来の MutationObserver 側の判定はロールだけで短絡していたため、`<div role="status" aria-atomic="false">` でも常にアトミック扱いになっていました。暗黙値は維持しつつ、明示的な `aria-atomic="false"` を尊重するよう修正しました。

これにより、同ファイルの `handleAlertAppearance`（`!== "false"` で判定）とも挙動が一致します。

### `aria-relevant` の `text` トークンの判定

従来は `additions` / `removals` / `all` のみを見ており、characterData 変化（テキスト変更）は `aria-relevant` の内容にかかわらず常に通知対象になっていました。`aria-relevant="additions"`（`text` なし）を指定したリージョンではテキスト変更を通知しないよう、`text`（または `all`）のガードを追加しました。

デフォルト値は `"additions text"` のままなので、未指定時の挙動は変わりません。

## テスト

- `pnpm lint-fix` 実行済み
- `pnpm --filter=@a11y-visualizer/browser-extension compile`（型チェック）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)