### PR TITLE
fix: target-sizeで密集ターゲットと孤立した小さいターゲットを区別

### DIFF
--- a/.changeset/target-size-crowded-vs-small.md
+++ b/.changeset/target-size-crowded-vs-small.md
@@ -1,0 +1,9 @@
+---
+"@a11y-visualizer/browser-extension": patch
+"@a11y-visualizer/rules": patch
+---
+
+Refine target-size warnings to distinguish crowded targets from isolated small targets:
+
+- A small target that is close to another target (inadequate spacing) is now reported as "Crowded small targets".
+- A small target with adequate spacing (including an isolated target with no nearby targets) is now consistently reported as "Small target", instead of being suppressed when other targets exist elsewhere on the page.

--- a/apps/browser_extension/src/i18n/en.json
+++ b/apps/browser_extension/src/i18n/en.json
@@ -129,6 +129,7 @@
   "May be skipped": "May be skipped",
   "inert": "inert",
   "Small target": "Small target",
+  "Crowded small targets": "Crowded small targets",
   "Heading level": "Heading level",
   "Page language": "Page language",
   "Table size": "Table size",

--- a/apps/browser_extension/src/i18n/ja.json
+++ b/apps/browser_extension/src/i18n/ja.json
@@ -129,6 +129,7 @@
   "May be skipped": "読み飛ばされる可能性あり",
   "inert": "inert",
   "Small target": "ターゲットが小さい",
+  "Crowded small targets": "小さいターゲットが密集",
   "Heading level": "見出しレベル",
   "Page language": "ページの言語",
   "Table size": "テーブルのサイズ",

--- a/apps/browser_extension/src/i18n/ko.json
+++ b/apps/browser_extension/src/i18n/ko.json
@@ -129,6 +129,7 @@
   "May be skipped": "May be skipped",
   "inert": "inert",
   "Small target": "Small target",
+  "Crowded small targets": "작은 타겟이 밀집",
   "Heading level": "헤딩 레벨",
   "Page language": "Page language",
   "Table size": "Table size",

--- a/packages/rules/src/target-size/index.test.ts
+++ b/packages/rules/src/target-size/index.test.ts
@@ -223,9 +223,21 @@ describe(TargetSize.ruleName, () => {
 
     document.body.appendChild(container);
 
-    // Both buttons should not show warnings due to adequate spacing
-    expect(TargetSize.evaluate(el1, { enabled: true }, {})).toBeUndefined();
-    expect(TargetSize.evaluate(el2, { enabled: true }, {})).toBeUndefined();
+    // Adequately spaced but still small → "Small target" warning
+    expect(TargetSize.evaluate(el1, { enabled: true }, {})).toEqual([
+      {
+        type: "warning",
+        message: "Small target",
+        ruleName: "target-size",
+      },
+    ]);
+    expect(TargetSize.evaluate(el2, { enabled: true }, {})).toEqual([
+      {
+        type: "warning",
+        message: "Small target",
+        ruleName: "target-size",
+      },
+    ]);
   });
 
   test("small button with inadequate spacing", () => {
@@ -258,18 +270,18 @@ describe(TargetSize.ruleName, () => {
 
     document.body.appendChild(container);
 
-    // Both buttons should show warnings due to inadequate spacing
+    // Both buttons are small and crowded → "Crowded small targets" warning
     expect(TargetSize.evaluate(el1, { enabled: true }, {})).toEqual([
       {
         type: "warning",
-        message: "Small target",
+        message: "Crowded small targets",
         ruleName: "target-size",
       },
     ]);
     expect(TargetSize.evaluate(el2, { enabled: true }, {})).toEqual([
       {
         type: "warning",
-        message: "Small target",
+        message: "Crowded small targets",
         ruleName: "target-size",
       },
     ]);
@@ -305,11 +317,11 @@ describe(TargetSize.ruleName, () => {
 
     document.body.appendChild(container);
 
-    // Small button should show warning due to inadequate spacing with large button
+    // Small button should show crowded warning due to inadequate spacing with large button
     expect(TargetSize.evaluate(smallButton, { enabled: true }, {})).toEqual([
       {
         type: "warning",
-        message: "Small target",
+        message: "Crowded small targets",
         ruleName: "target-size",
       },
     ]);
@@ -453,7 +465,7 @@ describe(TargetSize.ruleName, () => {
 
     document.body.appendChild(container);
 
-    // Both buttons should not show warnings due to adequate spacing
+    // Adequately spaced but still small → "Small target" warning
     expect(
       TargetSize.evaluate(
         docButton,
@@ -462,7 +474,13 @@ describe(TargetSize.ruleName, () => {
           shadowRoots: [shadowRoot],
         },
       ),
-    ).toBeUndefined();
+    ).toEqual([
+      {
+        type: "warning",
+        message: "Small target",
+        ruleName: "target-size",
+      },
+    ]);
     expect(
       TargetSize.evaluate(
         shadowButton,
@@ -471,7 +489,13 @@ describe(TargetSize.ruleName, () => {
           shadowRoots: [shadowRoot],
         },
       ),
-    ).toBeUndefined();
+    ).toEqual([
+      {
+        type: "warning",
+        message: "Small target",
+        ruleName: "target-size",
+      },
+    ]);
   });
 
   test("multiple Shadow DOMs with target elements", () => {
@@ -510,7 +534,7 @@ describe(TargetSize.ruleName, () => {
 
     document.body.appendChild(container);
 
-    // Both buttons should not show warnings due to adequate spacing
+    // Adequately spaced but still small → "Small target" warning
     expect(
       TargetSize.evaluate(
         button1,
@@ -519,7 +543,13 @@ describe(TargetSize.ruleName, () => {
           shadowRoots: [shadowRoot1, shadowRoot2],
         },
       ),
-    ).toBeUndefined();
+    ).toEqual([
+      {
+        type: "warning",
+        message: "Small target",
+        ruleName: "target-size",
+      },
+    ]);
     expect(
       TargetSize.evaluate(
         button2,
@@ -528,7 +558,13 @@ describe(TargetSize.ruleName, () => {
           shadowRoots: [shadowRoot1, shadowRoot2],
         },
       ),
-    ).toBeUndefined();
+    ).toEqual([
+      {
+        type: "warning",
+        message: "Small target",
+        ruleName: "target-size",
+      },
+    ]);
   });
 
   test("isolated small button in Shadow DOM (no other targets)", () => {
@@ -541,7 +577,7 @@ describe(TargetSize.ruleName, () => {
     shadowRoot.appendChild(el);
     document.body.appendChild(host);
 
-    // Isolated target should show warning (spacing exception doesn't apply)
+    // Isolated small target is adequately spaced → "Small target" warning
     expect(
       TargetSize.evaluate(el, { enabled: true }, { shadowRoots: [shadowRoot] }),
     ).toEqual([

--- a/packages/rules/src/target-size/index.ts
+++ b/packages/rules/src/target-size/index.ts
@@ -58,22 +58,30 @@ export const TargetSize: RuleObject = {
       return undefined;
     }
     if (
-      isSmallTarget(element, elementDocument, elementWindow, shadowRoots) &&
-      !(
-        isInline(element) ||
-        isDefaultSize(element) ||
-        hasAdequateSpacing(element, elementDocument, shadowRoots)
-      )
+      !isSmallTarget(element, elementDocument, elementWindow, shadowRoots) ||
+      isInline(element) ||
+      isDefaultSize(element)
     ) {
+      return undefined;
+    }
+    // 周囲に他のターゲットがある(間隔が不十分)場合は「密集」として警告し、
+    // 単独で十分な間隔がある場合は「小さい」として警告する
+    if (!hasAdequateSpacing(element, elementDocument)) {
       return [
         {
           type: "warning",
-          message: "Small target",
+          message: "Crowded small targets",
           ruleName,
         },
       ];
     }
-    return undefined;
+    return [
+      {
+        type: "warning",
+        message: "Small target",
+        ruleName,
+      },
+    ];
   },
 };
 
@@ -130,19 +138,9 @@ const isSmallTarget = (
 const hasAdequateSpacing = (
   element: Element,
   elementDocument: Document,
-  shadowRoots?: ShadowRoot[],
 ): boolean => {
-  // First, check if there are any other target elements in the document
-  // If not, spacing exception doesn't apply (isolated targets should show warnings)
-  const hasOtherTargets = hasOtherTargetsInDocument(
-    element,
-    elementDocument,
-    shadowRoots,
-  );
-  if (!hasOtherTargets) {
-    return false;
-  }
-
+  // 周囲24px内に他のターゲットがなければ間隔は十分(孤立したターゲットは
+  // 自明に間隔を満たす)。他のターゲットが交差する場合のみ間隔不十分とする。
   // Use getBoundingClientRect for viewport coordinates (matches elementFromPoint)
   const rect = element.getBoundingClientRect();
 
@@ -262,28 +260,6 @@ const isExtensionElement = (element: Element): boolean => {
     }
     current = current.parentElement;
   }
-  return false;
-};
-
-const hasOtherTargetsInDocument = (
-  element: Element,
-  elementDocument: Document,
-  shadowRoots?: ShadowRoot[],
-): boolean => {
-  // Use combined selector for efficient single query
-  const allTargets = querySelectorAllFromRoots(
-    COMBINED_SELECTOR,
-    elementDocument,
-    shadowRoots,
-  );
-
-  // Check if any target other than the current element exists
-  for (const target of allTargets) {
-    if (target !== element) {
-      return true;
-    }
-  }
-
   return false;
 };
 


### PR DESCRIPTION
## 概要

`target-size` ルール(WCAG 2.5.8 Target Size)の間隔判定を修正しました。

これまで `hasAdequateSpacing` は「文書内に他のターゲットが1つも存在しない場合」に `false`(間隔不十分)を返していました。しかし WCAG 2.5.8 の Spacing 例外は「対象の24px円が他のターゲットと交差しないこと」であり、**孤立した小さいターゲットは自明に例外を満たす**ため、この扱いは例外規定と逆でした。

## 変更内容

小さいターゲット(inline / デフォルトサイズを除く)に対して、間隔の状況に応じてメッセージを出し分けるようにしました。

- **間隔が不十分**(周囲24px内に他のターゲットがある = 密集)→ `Crowded small targets`(`小さいターゲットが密集`)
- **間隔が十分・孤立している** → 従来通り `Small target`(`ターゲットが小さい`)
  - これまで「他のターゲットがページ内の別の場所に存在する」場合に警告が抑制されていたケースも、小さいターゲットとして警告するようになりました

## 挙動の変化

| ケース | 変更前 | 変更後 |
|---|---|---|
| 孤立した小さいターゲット | Small target | Small target(変化なし) |
| 間隔が十分な小さいターゲット | 警告なし | **Small target** |
| 密集した小さいターゲット | Small target | **Crowded small targets** |

## テスト

- `packages/rules` の全テストがパス(1051 passed / 1 skipped)
- 挙動が変わるテストケースを更新
- 新しい警告メッセージの翻訳(en / ja / ko)を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)