### PR TITLE
fix: lang/xml:langの値をBCP47言語タグとして構文検証

### DIFF
--- a/.changeset/lang-bcp47-validation.md
+++ b/.changeset/lang-bcp47-validation.md
@@ -1,0 +1,6 @@
+---
+"@a11y-visualizer/rules": patch
+"@a11y-visualizer/browser-extension": patch
+---
+
+Validate `lang` / `xml:lang` values as BCP 47 (RFC 5646) language tags. Syntactically invalid values (e.g. `lang="japanese"`) are now reported as an error, since WCAG 3.1.1 / 3.1.2 require a valid language tag.

--- a/apps/browser_extension/src/i18n/en.json
+++ b/apps/browser_extension/src/i18n/en.json
@@ -120,6 +120,7 @@
   "Empty title attribute": "Empty title attribute",
   "Not associated with any control": "Not associated with any control",
   "lang and xml:lang attributes must have the same value": "lang and xml:lang attributes must have the same value",
+  "Invalid language tag format": "Invalid language tag format",
   "No href attribute": "No href attribute",
   "Nested interactive element": "Nested interactive element",
   "No lang attribute on <html>": "No lang attribute on <html>",

--- a/apps/browser_extension/src/i18n/ja.json
+++ b/apps/browser_extension/src/i18n/ja.json
@@ -120,6 +120,7 @@
   "Empty title attribute": "title属性が空",
   "Not associated with any control": "入力欄等と紐付けされていない",
   "lang and xml:lang attributes must have the same value": "lang属性とxml:lang属性の値が異なる",
+  "Invalid language tag format": "言語タグ形式が不正",
   "No href attribute": "href属性なし",
   "Nested interactive element": "インタラクティブ要素の入れ子",
   "No lang attribute on <html>": "<html>要素にlang属性なし",

--- a/apps/browser_extension/src/i18n/ko.json
+++ b/apps/browser_extension/src/i18n/ko.json
@@ -120,6 +120,7 @@
   "Empty title attribute": "빈 title 속성",
   "Not associated with any control": "폼 컨트롤 등과 연결되지 없음",
   "lang and xml:lang attributes must have the same value": "lang and xml:lang attributes must have the same value",
+  "Invalid language tag format": "잘못된 언어 태그 형식",
   "No href attribute": "href속성 없음",
   "Nested interactive element": "Nested interactive element",
   "No lang attribute on <html>": "No lang attribute on <html>",

--- a/packages/rules/src/bcp47.test.ts
+++ b/packages/rules/src/bcp47.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import { isWellFormedLanguageTag } from "./bcp47";
+
+describe("isWellFormedLanguageTag", () => {
+  test.each([
+    "en",
+    "ja",
+    "EN",
+    "en-US",
+    "en-us",
+    "zh-Hans",
+    "zh-Hans-CN",
+    "es-419",
+    "de-CH-1901",
+    "sl-rozaj-biske",
+    "en-a-bbb-x-a-ccc",
+    "x-private",
+    "hak", // 3-letter primary language
+    "i-klingon", // grandfathered
+    "zh-min-nan", // grandfathered
+  ])("valid: %s", (tag) => {
+    expect(isWellFormedLanguageTag(tag)).toBe(true);
+  });
+
+  test.each([
+    "japanese",
+    "english",
+    "en_US", // underscore is not allowed
+    "en-", // trailing hyphen
+    "-en",
+    "123",
+    "e",
+    "a-DE",
+    "en--US",
+    "",
+  ])("invalid: %s", (tag) => {
+    expect(isWellFormedLanguageTag(tag)).toBe(false);
+  });
+});

--- a/packages/rules/src/bcp47.ts
+++ b/packages/rules/src/bcp47.ts
@@ -1,0 +1,71 @@
+/**
+ * BCP 47 (RFC 5646) の言語タグとして構文的に妥当かどうかを判定する
+ *
+ * 言語コードの実在性（例: `jp` が言語として存在するか）ではなく、
+ * あくまで書式（well-formedness）のみを検証する。`japanese` のような
+ * 明らかに言語タグでない値を検出する用途を想定している。
+ */
+
+// RFC 5646 で定義される grandfathered（irregular / regular）タグ。
+// 正規表現の一般ルールに当てはまらないため個別に許可する（小文字で保持）
+const GRANDFATHERED = [
+  // irregular
+  "en-gb-oed",
+  "i-ami",
+  "i-bnn",
+  "i-default",
+  "i-enochian",
+  "i-hak",
+  "i-klingon",
+  "i-lux",
+  "i-mingo",
+  "i-navajo",
+  "i-pwn",
+  "i-tao",
+  "i-tay",
+  "i-tsu",
+  "sgn-be-fr",
+  "sgn-be-nl",
+  "sgn-ch-de",
+  // regular
+  "art-lojban",
+  "cel-gaulish",
+  "no-bok",
+  "no-nyn",
+  "zh-guoyu",
+  "zh-hakka",
+  "zh-min",
+  "zh-min-nan",
+  "zh-xiang",
+];
+
+// RFC 5646 の langtag の ABNF を反映した正規表現（大文字小文字は無視）。
+// ABNF 上は 5〜8文字の primary language subtag も許容されるが、IANA レジストリ
+// に実在せず `japanese` / `english` のような誤った値を通してしまうため、
+// 実用上は 2〜4文字（ISO 639 の 2〜3文字 + extlang、または将来予約の4文字）に限定する
+const language = "(?:[a-z]{2,3}(?:-[a-z]{3}){0,3}|[a-z]{4})";
+const script = "(?:-[a-z]{4})?";
+const region = "(?:-(?:[a-z]{2}|[0-9]{3}))?";
+const variant = "(?:-(?:[a-z0-9]{5,8}|[0-9][a-z0-9]{3}))*";
+const extension = "(?:-[0-9a-wy-z](?:-[a-z0-9]{2,8})+)*";
+const privateuse = "(?:-x(?:-[a-z0-9]{1,8})+)?";
+const langtag = `${language}${script}${region}${variant}${extension}${privateuse}`;
+const privateuseOnly = "x(?:-[a-z0-9]{1,8})+";
+
+const LANGUAGE_TAG_PATTERN = new RegExp(
+  `^(?:${langtag}|${privateuseOnly})$`,
+  "i",
+);
+
+/**
+ * 言語タグが BCP 47 (RFC 5646) の書式として妥当かどうかを返す
+ *
+ * @param tag - 検証する言語タグの文字列
+ * @returns 書式として妥当な場合は true
+ */
+export const isWellFormedLanguageTag = (tag: string): boolean => {
+  if (GRANDFATHERED.includes(tag.toLowerCase())) {
+    return true;
+  }
+  return LANGUAGE_TAG_PATTERN.test(tag);
+};

--- a/packages/rules/src/lang/index.test.ts
+++ b/packages/rules/src/lang/index.test.ts
@@ -53,6 +53,44 @@ describe("lang", () => {
     ]);
   });
 
+  test("span with invalid lang tag", () => {
+    const element = document.createElement("span");
+    element.setAttribute("lang", "japanese");
+    document.body.appendChild(element);
+    const result = Lang.evaluate(element, { enabled: true }, {});
+    expect(result).toEqual([
+      {
+        type: "error",
+        ruleName: "lang",
+        message: "Invalid language tag format",
+      },
+    ]);
+  });
+
+  test("span with invalid xml:lang tag", () => {
+    const element = document.createElement("span");
+    element.setAttribute("xml:lang", "en_US");
+    document.body.appendChild(element);
+    const result = Lang.evaluate(element, { enabled: true }, {});
+    expect(result).toEqual([
+      {
+        type: "error",
+        ruleName: "lang",
+        message: "Invalid language tag format",
+      },
+    ]);
+  });
+
+  test("span with region subtag", () => {
+    const element = document.createElement("span");
+    element.setAttribute("lang", "en-US");
+    document.body.appendChild(element);
+    const result = Lang.evaluate(element, { enabled: true }, {});
+    expect(result).toEqual([
+      { type: "lang", ruleName: "lang", content: "en-US" },
+    ]);
+  });
+
   test("disabled", () => {
     const element = document.createElement("span");
     element.setAttribute("lang", "en");

--- a/packages/rules/src/lang/index.ts
+++ b/packages/rules/src/lang/index.ts
@@ -1,3 +1,4 @@
+import { isWellFormedLanguageTag } from "../bcp47";
 import type { RuleObject } from "../type";
 
 const ruleName = "lang";
@@ -24,7 +25,17 @@ export const Lang: RuleObject = {
         },
       ];
     } else if (lang || xmlLang) {
-      return [{ type: "lang", ruleName, content: `${lang || xmlLang}` }];
+      const value = `${lang || xmlLang}`;
+      if (!isWellFormedLanguageTag(value)) {
+        return [
+          {
+            type: "error",
+            ruleName,
+            message: "Invalid language tag format",
+          },
+        ];
+      }
+      return [{ type: "lang", ruleName, content: value }];
     }
     return undefined;
   },

--- a/packages/rules/src/page-lang/index.test.ts
+++ b/packages/rules/src/page-lang/index.test.ts
@@ -72,6 +72,31 @@ describe("page-lang", () => {
     ]);
   });
 
+  test("html with invalid lang tag", () => {
+    document.documentElement.setAttribute("lang", "japanese");
+    const result = PageLang.evaluate(document.body, { enabled: true }, {});
+    expect(result).toEqual([
+      {
+        type: "error",
+        ruleName: "page-lang",
+        message: "Invalid language tag format",
+      },
+    ]);
+  });
+
+  test("html with region subtag", () => {
+    document.documentElement.setAttribute("lang", "en-US");
+    const result = PageLang.evaluate(document.body, { enabled: true }, {});
+    expect(result).toEqual([
+      {
+        type: "lang",
+        ruleName: "page-lang",
+        content: "en-US",
+        contentLabel: "Page language",
+      },
+    ]);
+  });
+
   test("disabled", () => {
     document.documentElement.setAttribute("lang", "en");
     const result = PageLang.evaluate(document.body, { enabled: false }, {});

--- a/packages/rules/src/page-lang/index.ts
+++ b/packages/rules/src/page-lang/index.ts
@@ -1,3 +1,4 @@
+import { isWellFormedLanguageTag } from "../bcp47";
 import type { RuleObject } from "../type";
 
 const ruleName = "page-lang";
@@ -37,11 +38,21 @@ export const PageLang: RuleObject = {
     }
 
     if (lang || xmlLang) {
+      const value = `${lang || xmlLang}`;
+      if (!isWellFormedLanguageTag(value)) {
+        return [
+          {
+            type: "error",
+            ruleName,
+            message: "Invalid language tag format",
+          },
+        ];
+      }
       return [
         {
           type: "lang",
           ruleName,
-          content: `${lang || xmlLang}`,
+          content: value,
           contentLabel: "Page language",
         },
       ];


### PR DESCRIPTION
## 概要

`lang` / `page-lang` ルールで、`lang`・`xml:lang` 属性の値がBCP 47 (RFC 5646) の言語タグとして構文的に妥当かを検証するようにしました。

これまでは属性の存在チェックと `lang` / `xml:lang` の一致チェックのみで、`lang="japanese"` のようなBCP 47として不正な値を検出できていませんでした。WCAG 3.1.1 / 3.1.2 の達成には妥当な言語タグであることが必要であり、不正な値はむしろ支援技術に悪影響を与えるため、構文チェックを追加しています。

## 変更内容

- `packages/rules/src/bcp47.ts` を追加し、BCP 47 (RFC 5646) の言語タグ書式（well-formedness）を検証する `isWellFormedLanguageTag` を実装
  - RFC 5646 の ABNF に沿った検証（script / region / variant / extension / private-use / grandfathered タグに対応）
  - ABNF 上は 5〜8文字の primary language subtag も許容されますが、IANAレジストリに実在せず `japanese` / `english` のような誤値を通してしまうため、実用上は2〜4文字に限定しています
- `lang` / `page-lang` ルールで、値が不正な場合に「言語タグ形式が不正 (Invalid language tag format)」エラーを表示
- i18n (en / ja / ko) にメッセージを追加
- 各種テストを追加

## テスト

- `pnpm --filter=@a11y-visualizer/rules test` : 全パス
- `pnpm --filter=@a11y-visualizer/browser-extension compile` : パス
- `pnpm lint-fix` : 実行済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)