### PR TITLE
fix: ルールをHTML/WAI-ARIA仕様により整合させる

### DIFF
--- a/.changeset/minor-rule-spec-fixes.md
+++ b/.changeset/minor-rule-spec-fixes.md
@@ -1,0 +1,12 @@
+---
+"@a11y-visualizer/dom-utils": patch
+"@a11y-visualizer/rules": patch
+---
+
+Align several rules more closely with the HTML and WAI-ARIA specifications:
+
+- `<label for="...">` with an unresolvable or non-labelable reference no longer falls back to a contained control, matching HTML's labeled-control resolution.
+- Descendants of a disabled `<fieldset>`'s first `<legend>` are no longer reported as disabled, per the HTML exception.
+- Radio buttons are grouped by their form owner, so the `form` attribute is honored and same-named radios in different forms are treated as separate groups.
+- Nested interactive detection now also catches descendants with an interactive ARIA role (e.g. `role="button"`) that lack `tabindex`.
+- `<optgroup>` now correctly resolves to the `group` role.

--- a/packages/dom-utils/src/getComputedImplicitRole.test.ts
+++ b/packages/dom-utils/src/getComputedImplicitRole.test.ts
@@ -395,10 +395,8 @@ describe("getComputedImplicitRole", () => {
     const meter = document.createElement("meter");
     expect(getComputedImplicitRole(meter)).toBe("meter");
 
-    // Note: There's a typo in the implementation "optgrouop" instead of "optgroup"
-    // So optgroup elements return null, not "group"
     const optgroup = document.createElement("optgroup");
-    expect(getComputedImplicitRole(optgroup)).toBe(null);
+    expect(getComputedImplicitRole(optgroup)).toBe("group");
 
     const option = document.createElement("option");
     expect(getComputedImplicitRole(option)).toBe("option");

--- a/packages/dom-utils/src/getComputedImplicitRole.ts
+++ b/packages/dom-utils/src/getComputedImplicitRole.ts
@@ -297,7 +297,7 @@ export const getComputedImplicitRole = (el: Element): ComputedRole | null => {
       return "html-object";
     case "ol":
       return "list";
-    case "optgrouop":
+    case "optgroup":
       return "group";
     case "option":
       return "option";

--- a/packages/dom-utils/src/hasInteractiveDescendant.test.ts
+++ b/packages/dom-utils/src/hasInteractiveDescendant.test.ts
@@ -14,4 +14,28 @@ describe("hasInteractiveDescendant", () => {
     el.appendChild(link);
     expect(hasInteractiveDescendant(el)).toBe(true);
   });
+
+  test("descendant with interactive role but no tabindex", () => {
+    const el = document.createElement("button");
+    const widget = document.createElement("div");
+    widget.setAttribute("role", "button");
+    el.appendChild(widget);
+    expect(hasInteractiveDescendant(el)).toBe(true);
+  });
+
+  test("descendant with interactive role as a token", () => {
+    const el = document.createElement("button");
+    const widget = document.createElement("div");
+    widget.setAttribute("role", "invalidrole checkbox");
+    el.appendChild(widget);
+    expect(hasInteractiveDescendant(el)).toBe(true);
+  });
+
+  test("descendant with non-interactive role", () => {
+    const el = document.createElement("button");
+    const child = document.createElement("div");
+    child.setAttribute("role", "presentation");
+    el.appendChild(child);
+    expect(hasInteractiveDescendant(el)).toBe(false);
+  });
 });

--- a/packages/dom-utils/src/hasInteractiveDescendant.ts
+++ b/packages/dom-utils/src/hasInteractiveDescendant.ts
@@ -1,9 +1,32 @@
 /**
+ * インタラクティブなロールを持つ要素を表すロール一覧。
+ * HTML仕様のinteractive contentに相当する要素はタグ名で検出するため、
+ * ここではrole属性で明示されたウィジェット系ロールを補完的に検出する
+ */
+const INTERACTIVE_ROLES = [
+  "button",
+  "checkbox",
+  "combobox",
+  "link",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "option",
+  "radio",
+  "searchbox",
+  "slider",
+  "spinbutton",
+  "switch",
+  "tab",
+  "textbox",
+] as const;
+
+/**
  * インタラクティブなHTML要素（リンク、ボタン、フォームコントロールなど）を
  * 子孫に持つかどうかを判定する
  *
- * HTML仕様のinteractive contentに相当する要素をタグ名ベースで検出する。
- * role属性によるインタラクティブ要素は検出しない。
+ * HTML仕様のinteractive contentに相当する要素をタグ名ベースで検出するほか、
+ * role属性でインタラクティブなロールが明示された要素も検出する。
  * インタラクティブ要素の入れ子（nested-interactiveルール）の検出に使う
  *
  * @param el - 対象の要素（要素自身は判定対象に含まれない）
@@ -24,6 +47,7 @@ export const hasInteractiveDescendant = (el: Element): boolean => {
       "select",
       "textarea",
       "video",
+      ...INTERACTIVE_ROLES.map((role) => `[role~="${role}"]`),
     ].join(","),
   );
 };

--- a/packages/rules/src/aria-state/index.test.ts
+++ b/packages/rules/src/aria-state/index.test.ts
@@ -155,6 +155,59 @@ describe("aria-state", () => {
     ]);
   });
 
+  test("not disabled inside the first legend of a disabled fieldset", () => {
+    const fieldset = document.createElement("fieldset");
+    fieldset.setAttribute("disabled", "disabled");
+    document.body.appendChild(fieldset);
+    const legend = document.createElement("legend");
+    fieldset.appendChild(legend);
+    const element = document.createElement("button");
+    legend.appendChild(element);
+    const result = AriaState.evaluate(element, { enabled: true }, {});
+    expect(result).toBeUndefined();
+  });
+
+  test("disabled inside a legend that is not the first legend", () => {
+    const fieldset = document.createElement("fieldset");
+    fieldset.setAttribute("disabled", "disabled");
+    document.body.appendChild(fieldset);
+    const firstLegend = document.createElement("legend");
+    fieldset.appendChild(firstLegend);
+    const secondLegend = document.createElement("legend");
+    fieldset.appendChild(secondLegend);
+    const element = document.createElement("button");
+    secondLegend.appendChild(element);
+    const result = AriaState.evaluate(element, { enabled: true }, {});
+    expect(result).toEqual([
+      {
+        type: "state",
+        ruleName: "aria-state",
+        state: "Disabled: true",
+      },
+    ]);
+  });
+
+  test("disabled by an outer fieldset even when inside an inner legend", () => {
+    const outer = document.createElement("fieldset");
+    outer.setAttribute("disabled", "disabled");
+    document.body.appendChild(outer);
+    const inner = document.createElement("fieldset");
+    inner.setAttribute("disabled", "disabled");
+    outer.appendChild(inner);
+    const legend = document.createElement("legend");
+    inner.appendChild(legend);
+    const element = document.createElement("button");
+    legend.appendChild(element);
+    const result = AriaState.evaluate(element, { enabled: true }, {});
+    expect(result).toEqual([
+      {
+        type: "state",
+        ruleName: "aria-state",
+        state: "Disabled: true",
+      },
+    ]);
+  });
+
   test('aria-expanded="true"', () => {
     const element = document.createElement("div");
     element.setAttribute("role", "button");

--- a/packages/rules/src/aria-state/index.ts
+++ b/packages/rules/src/aria-state/index.ts
@@ -60,6 +60,24 @@ const getNativeCheckedValue = (element: Element) => {
   return null;
 };
 
+/**
+ * disabled属性を持つfieldsetの子孫であることによって無効化されているかを判定する。
+ * HTML仕様上、fieldsetの最初のlegend要素の子孫は無効化の対象外になる
+ */
+const isDisabledByFieldset = (element: Element): boolean => {
+  let fieldset = element.closest("fieldset[disabled]");
+  while (fieldset) {
+    const legend = fieldset.querySelector(":scope > legend");
+    if (!legend?.contains(element)) {
+      return true;
+    }
+    // 最初のlegend内にあるためこのfieldsetでは無効化されないが、
+    // さらに上位のdisabledなfieldsetによって無効化される可能性を確認する
+    fieldset = fieldset.parentElement?.closest("fieldset[disabled]") ?? null;
+  }
+  return false;
+};
+
 const getNativeDisabledValue = (element: Element) => {
   const tagName = element.tagName.toLowerCase();
   if (
@@ -75,7 +93,7 @@ const getNativeDisabledValue = (element: Element) => {
   ) {
     return (element as HTMLInputElement).disabled
       ? "true"
-      : element.closest("fieldset[disabled]")
+      : isDisabledByFieldset(element)
         ? "true"
         : null;
   }

--- a/packages/rules/src/label-associated-control/index.test.ts
+++ b/packages/rules/src/label-associated-control/index.test.ts
@@ -73,6 +73,49 @@ describe("label-associated-control", () => {
     expect(result).toBeUndefined();
   });
 
+  test("label with unresolved for does not fall back to a contained control", () => {
+    const element = document.createElement("label");
+    element.setAttribute("for", "missing");
+    const input = document.createElement("input");
+    element.appendChild(input);
+    document.body.appendChild(element);
+    const result = LabelAssociatedControl.evaluate(
+      element,
+      { enabled: true },
+      {},
+    );
+    expect(result).toEqual([
+      {
+        type: "warning",
+        ruleName: "label-associated-control",
+        message: "Not associated with any control",
+      },
+    ]);
+  });
+
+  test("label with for pointing to non-labelable element does not fall back", () => {
+    const element = document.createElement("label");
+    element.setAttribute("for", "target");
+    const div = document.createElement("div");
+    div.id = "target";
+    const input = document.createElement("input");
+    element.appendChild(input);
+    document.body.appendChild(element);
+    document.body.appendChild(div);
+    const result = LabelAssociatedControl.evaluate(
+      element,
+      { enabled: true },
+      {},
+    );
+    expect(result).toEqual([
+      {
+        type: "warning",
+        ruleName: "label-associated-control",
+        message: "Not associated with any control",
+      },
+    ]);
+  });
+
   test("iframe: label[for] resolves inside iframe document", () => {
     const iframe = document.createElement("iframe");
     document.body.appendChild(iframe);

--- a/packages/rules/src/label-associated-control/index.ts
+++ b/packages/rules/src/label-associated-control/index.ts
@@ -26,18 +26,21 @@ export const LabelAssociatedControl: RuleObject = {
     }
 
     const forAttr = element.getAttribute("for");
-    const forElement = forAttr
-      ? getElementByIdFromRoots(forAttr, elementDocument, shadowRoots)
-      : null;
-    const controlByFor = forElement?.matches(LABELABLE_SELECTOR)
-      ? forElement
-      : null;
-    const controlInside = element.querySelector(LABELABLE_SELECTOR);
-    if (
-      (!controlByFor && !controlInside) ||
-      (controlByFor && isHidden(controlByFor)) ||
-      (controlInside && isHidden(controlInside))
-    ) {
+    // HTML仕様上、for属性が指定されている場合は参照先のIDで関連コントロールが
+    // 決まり、参照が解決できなくても内包コントロールへのフォールバックは
+    // 発生しない。for属性がない場合のみ内包コントロールが関連付けられる
+    let control: Element | null;
+    if (forAttr !== null) {
+      const forElement = getElementByIdFromRoots(
+        forAttr,
+        elementDocument,
+        shadowRoots,
+      );
+      control = forElement?.matches(LABELABLE_SELECTOR) ? forElement : null;
+    } else {
+      control = element.querySelector(LABELABLE_SELECTOR);
+    }
+    if (!control || isHidden(control)) {
       return [
         {
           type: "warning",

--- a/packages/rules/src/landmark/index.ts
+++ b/packages/rules/src/landmark/index.ts
@@ -96,6 +96,9 @@ export const Landmark: RuleObject = {
     }
 
     if (tagToRole[tagName]) {
+      // HTML-AAM上はアクセシブルな名前のない<form>はformランドマークとして
+      // 露出されないが、ここでは名前の有無によらずランドマークとして表示する。
+      // <form>であることをユーザーに明示することが目的
       return [
         {
           type: "landmark",

--- a/packages/rules/src/nested-interactive/index.test.ts
+++ b/packages/rules/src/nested-interactive/index.test.ts
@@ -113,6 +113,16 @@ describe("nested-interactive", () => {
     expect(childResult).toEqual(errorResult);
   });
 
+  test("interactive role without tabindex in button", () => {
+    const element = document.createElement("button");
+    const child = document.createElement("div");
+    child.setAttribute("role", "button");
+    element.appendChild(child);
+    document.body.appendChild(element);
+    const result = NestedInteractive.evaluate(element, { enabled: true }, {});
+    expect(result).toEqual(errorResult);
+  });
+
   test("input in button", () => {
     const element = document.createElement("button");
     const child = document.createElement("input");

--- a/packages/rules/src/radio-group/index.test.ts
+++ b/packages/rules/src/radio-group/index.test.ts
@@ -47,4 +47,69 @@ describe("radio-group", () => {
     const result = RadioGroup.evaluate(element, { enabled: true }, {});
     expect(result).toBeUndefined();
   });
+
+  test("radios in different forms are not grouped together", () => {
+    const form1 = document.createElement("form");
+    document.body.appendChild(form1);
+    const form2 = document.createElement("form");
+    document.body.appendChild(form2);
+    const element = document.createElement("input");
+    element.type = "radio";
+    element.name = "group";
+    form1.appendChild(element);
+    const element2 = document.createElement("input");
+    element2.type = "radio";
+    element2.name = "group";
+    form2.appendChild(element2);
+    const result = RadioGroup.evaluate(element, { enabled: true }, {});
+    expect(result).toEqual([
+      {
+        type: "error",
+        message: "Ungrouped radio button",
+        ruleName: "radio-group",
+      },
+    ]);
+  });
+
+  test("radios grouped across DOM via form attribute", () => {
+    const form = document.createElement("form");
+    form.id = "myform";
+    document.body.appendChild(form);
+    const element = document.createElement("input");
+    element.type = "radio";
+    element.name = "group";
+    element.setAttribute("form", "myform");
+    document.body.appendChild(element);
+    const element2 = document.createElement("input");
+    element2.type = "radio";
+    element2.name = "group";
+    element2.setAttribute("form", "myform");
+    document.body.appendChild(element2);
+    const result = RadioGroup.evaluate(element, { enabled: true }, {});
+    expect(result).toBeUndefined();
+  });
+
+  test("form attribute overrides ancestor form for grouping", () => {
+    const form = document.createElement("form");
+    document.body.appendChild(form);
+    // 祖先のformに属する同名ラジオがあっても、form属性で別オーナーを
+    // 指すラジオは同じグループにならない
+    const inForm = document.createElement("input");
+    inForm.type = "radio";
+    inForm.name = "group";
+    form.appendChild(inForm);
+    const element = document.createElement("input");
+    element.type = "radio";
+    element.name = "group";
+    element.setAttribute("form", "nonexistent");
+    form.appendChild(element);
+    const result = RadioGroup.evaluate(element, { enabled: true }, {});
+    expect(result).toEqual([
+      {
+        type: "error",
+        message: "Ungrouped radio button",
+        ruleName: "radio-group",
+      },
+    ]);
+  });
 });

--- a/packages/rules/src/radio-group/index.ts
+++ b/packages/rules/src/radio-group/index.ts
@@ -1,15 +1,41 @@
-import { querySelectorAllFromRoots } from "@a11y-visualizer/dom-utils";
+import {
+  getElementByIdFromRoots,
+  querySelectorAllFromRoots,
+} from "@a11y-visualizer/dom-utils";
 import type { RuleObject } from "../type";
 
 const ruleName = "radio-group";
 const defaultOptions = {
   enabled: true,
 };
+
+/**
+ * 要素のフォームオーナーを求める。
+ * form属性が指定されていればそのIDで参照されるform要素が、なければ
+ * 最も近い祖先のform要素がフォームオーナーになる（HTML仕様準拠）。
+ * 同名のラジオボタンでもフォームオーナーが異なれば同じグループにならない
+ */
+const getFormOwner = (
+  element: Element,
+  elementDocument: Document,
+  shadowRoots?: ShadowRoot[],
+): Element | null => {
+  const formId = element.getAttribute("form");
+  if (formId !== null) {
+    const owner = getElementByIdFromRoots(formId, elementDocument, shadowRoots);
+    return owner?.tagName.toLowerCase() === "form" ? owner : null;
+  }
+  return element.closest("form");
+};
 export const RadioGroup: RuleObject = {
   ruleName,
   defaultOptions,
   selectors: ['input[type="radio"]'],
-  evaluate: (element, { enabled } = defaultOptions, { shadowRoots } = {}) => {
+  evaluate: (
+    element,
+    { enabled } = defaultOptions,
+    { elementDocument = element.ownerDocument, shadowRoots } = {},
+  ) => {
     if (!enabled) {
       return undefined;
     }
@@ -24,11 +50,14 @@ export const RadioGroup: RuleObject = {
         },
       ];
     } else {
-      const form = element.closest("form");
+      // 同名でもフォームオーナーが一致するラジオボタンだけが同じグループになる
+      const owner = getFormOwner(element, elementDocument, shadowRoots);
       const radios = querySelectorAllFromRoots(
         `input[type="radio"][name="${CSS.escape(nameAttr)}"]`,
-        form || element.ownerDocument,
+        elementDocument,
         shadowRoots,
+      ).filter(
+        (radio) => getFormOwner(radio, elementDocument, shadowRoots) === owner,
       );
       if (radios.length < 2) {
         return [


### PR DESCRIPTION
## 概要

各ルールの判定ロジックをHTMLおよびWAI-ARIA仕様により整合させ、誤検出・検出漏れを減らします。

## 変更内容

- **label-associated-control**: `<label for="...">` の参照先が解決できない（または labelable でない）場合、HTML仕様上は内包コントロールへのフォールバックが発生しないため、関連付けなしとして扱うよう修正
- **aria-state**: disabled な `<fieldset>` の最初の `<legend>` 内の子孫は無効化の対象外とするHTML仕様の例外に対応
- **radio-group**: フォームオーナー単位でグループを判定するようにし、`form` 属性による所属を考慮。異なるフォームの同名ラジオは別グループとして扱う
- **nested-interactive** (`hasInteractiveDescendant`): `tabindex` を持たない `role="button"` などのARIA製インタラクティブ要素の入れ子も検出できるように
- **getComputedImplicitRole**: `optgroup` のタイポ（`optgrouop`）を修正し、暗黙ロール `group` を返すように
- **landmark**: アクセシブルな名前のない `<form>` もランドマークとして表示する挙動は維持。`<form>` であることをユーザーに明示する意図であることをコメントで明記

## テスト

- 各修正に対応するテストを追加
- `pnpm test` / `pnpm lint` / 型チェックをパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)