### PR TITLE
テストページに開発者がやりがちなパターンのサンプルを追加

### DIFF
--- a/apps/website/src/components/tests/FormControlTests.astro
+++ b/apps/website/src/components/tests/FormControlTests.astro
@@ -345,6 +345,23 @@ const t = createLocalT(lang === "ja" ? ja : en, en);
   </p>
 </ExampleCard>
 
+<ExampleCard
+  title={t("examples.labels.missingIdWithControl.title")}
+  description={t("examples.labels.missingIdWithControl.desc")}
+>
+  <label
+    for="non-existent-input-with-control"
+    class="text-zinc-700 dark:text-zinc-300 border-red-300 border p-1 block mb-2"
+  >
+    Nickname
+    <input type="text" class={formClasses} />
+  </label>
+  <p class="text-sm text-zinc-600 dark:text-zinc-400">
+    The for attribute points to an id that doesn't exist, so the wrapped input
+    is not associated with this label.
+  </p>
+</ExampleCard>
+
 <CategorySectionTitle id="input-states"
   >{t("sections.inputStates.title")}</CategorySectionTitle
 >

--- a/apps/website/src/components/tests/FormControlTests.lang.ts
+++ b/apps/website/src/components/tests/FormControlTests.lang.ts
@@ -92,6 +92,10 @@ export const en = {
         title: "Label with non-existent ID reference",
         desc: "⚠️ Label references an ID that doesn't exist. Is the ID you meant to reference incorrect?",
       },
+      missingIdWithControl: {
+        title: "Label wrapping a control, with a non-existent ID reference",
+        desc: "❌ The label wraps an input, but its for attribute references an ID that doesn't exist. When the for attribute cannot be resolved, the wrapped control is not associated with the label.",
+      },
     },
     states: {
       required: {
@@ -213,6 +217,10 @@ export const ja = {
       missingId: {
         title: "存在しない ID を参照する label",
         desc: "⚠️ 対応する入力が存在していません。指定する ID を間違えていませんか？",
+      },
+      missingIdWithControl: {
+        title: "コントロールを内包しつつ、存在しない ID を参照する label",
+        desc: "❌ label は input を内包していますが、for 属性が存在しない ID を参照しています。for 属性が解決できない場合、内包するコントロールへの関連付けは行われません。",
       },
     },
     states: {

--- a/apps/website/src/components/tests/HeadingTests.astro
+++ b/apps/website/src/components/tests/HeadingTests.astro
@@ -101,3 +101,41 @@ const t = createLocalT(lang === "ja" ? ja : en, en);
     </p>
   </blockquote>
 </ExampleCard>
+
+<ExampleCard
+  title={t("examples.problematic.noAriaLevel.title")}
+  description={t("examples.problematic.noAriaLevel.desc")}
+>
+  <blockquote
+    class="p-4 border border-yellow-300 dark:border-yellow-600 rounded-sm bg-yellow-50 dark:bg-yellow-900/20"
+  >
+    <div
+      class="text-lg font-bold text-zinc-800 dark:text-zinc-200"
+      role="heading"
+    >
+      Custom Heading (role="heading" without aria-level)
+    </div>
+    <p class="text-sm text-zinc-700 dark:text-zinc-300 mt-2">
+      {t("examples.problematic.noAriaLevel.note")}
+    </p>
+  </blockquote>
+</ExampleCard>
+
+<ExampleCard
+  title={t("examples.problematic.ariaLevelOverride.title")}
+  description={t("examples.problematic.ariaLevelOverride.desc")}
+>
+  <blockquote
+    class="p-4 border border-yellow-300 dark:border-yellow-600 rounded-sm bg-yellow-50 dark:bg-yellow-900/20"
+  >
+    <h2
+      aria-level="4"
+      class="text-xl font-bold text-zinc-800 dark:text-zinc-200"
+    >
+      h2 element with aria-level="4"
+    </h2>
+    <p class="text-sm text-zinc-700 dark:text-zinc-300 mt-2">
+      {t("examples.problematic.ariaLevelOverride.note")}
+    </p>
+  </blockquote>
+</ExampleCard>

--- a/apps/website/src/components/tests/HeadingTests.lang.ts
+++ b/apps/website/src/components/tests/HeadingTests.lang.ts
@@ -30,6 +30,16 @@ export const en = {
         desc: "❌ Heading element with no text content. Assistive technology users cannot predict the content about the part with this heading.",
         note: "This h6 element contains no text and provides no value to users.",
       },
+      noAriaLevel: {
+        title: 'role="heading" without aria-level',
+        desc: '⚠️ A custom heading using role="heading" but without an aria-level attribute. Assistive technologies treat it as a level 2 heading by default, which may not match the intended document structure. Specify aria-level explicitly.',
+        note: "Without aria-level, this heading defaults to level 2.",
+      },
+      ariaLevelOverride: {
+        title: "aria-level overriding a native heading tag",
+        desc: '⚠️ An h2 element with aria-level="4". The ARIA attribute overrides the tag\'s native level, so assistive technologies treat it as a level 4 heading even though the markup says h2. This mismatch is confusing; prefer using the matching heading tag.',
+        note: "Assistive technologies expose this h2 as a level 4 heading.",
+      },
     },
   },
 } as const;
@@ -65,6 +75,16 @@ export const ja = {
         title: "空の見出し",
         desc: "❌ テキストのない見出し要素です。支援技術のユーザーは、この見出しのついた部分に何があるのか予想できません。",
         note: "この h6 要素にはテキストがなく、利用者に価値を提供しません。",
+      },
+      noAriaLevel: {
+        title: 'aria-level のない role="heading"',
+        desc: '⚠️ role="heading" を使いながら aria-level 属性を指定していないカスタム見出しです。支援技術はデフォルトでレベル 2 の見出しとして扱うため、意図した文書構造と一致しない場合があります。aria-level を明示しましょう。',
+        note: "aria-level がない場合、この見出しはレベル 2 として扱われます。",
+      },
+      ariaLevelOverride: {
+        title: "ネイティブの見出しタグを上書きする aria-level",
+        desc: '⚠️ aria-level="4" を指定した h2 要素です。ARIA 属性がタグ本来のレベルを上書きするため、マークアップ上は h2 でも支援技術はレベル 4 の見出しとして扱います。紛らわしいため、適切なレベルの見出しタグを使うことが望ましいです。',
+        note: "支援技術はこの h2 をレベル 4 の見出しとして扱います。",
       },
     },
   },

--- a/apps/website/src/components/tests/LiveRegionTests.astro
+++ b/apps/website/src/components/tests/LiveRegionTests.astro
@@ -113,6 +113,35 @@ const t = createLocalT(lang === "ja" ? ja : en, en);
   </div>
 </ExampleCard>
 
+<ExampleCard
+  title={t("examples.roles.alertVisibility.title")}
+  description={t("examples.roles.alertVisibility.desc")}
+>
+  <div class="space-y-4">
+    <div
+      id="toggle-visibility-alert"
+      role="alert"
+      class="hidden bg-orange-50 dark:bg-orange-900/20 p-3 rounded-sm border border-orange-200 dark:border-orange-700"
+    >
+      Error: Please fill in all required fields!
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <button
+        class="bg-zinc-600 text-white px-4 py-2 rounded-sm hover:bg-zinc-700 transition-colors"
+        onclick="document.getElementById('toggle-visibility-alert').classList.remove('hidden')"
+      >
+        Show Alert
+      </button>
+      <button
+        class="bg-gray-500 text-white px-4 py-2 rounded-sm hover:bg-gray-600 transition-colors"
+        onclick="document.getElementById('toggle-visibility-alert').classList.add('hidden')"
+      >
+        Hide Alert
+      </button>
+    </div>
+  </div>
+</ExampleCard>
+
 <CategorySectionTitle id="output-element"
   >{t("sections.output.title")}</CategorySectionTitle
 >

--- a/apps/website/src/components/tests/LiveRegionTests.lang.ts
+++ b/apps/website/src/components/tests/LiveRegionTests.lang.ts
@@ -34,6 +34,10 @@ export const en = {
         title: "role='alert'",
         desc: "Alert role for important, time-sensitive information. Equivalent to aria-live='assertive'.",
       },
+      alertVisibility: {
+        title: "Alert revealed by toggling visibility",
+        desc: "An alert element that exists in the DOM from page load but is hidden with display:none. Revealing it by toggling visibility is a common pattern for form errors. Screen readers announce the alert content when it becomes visible.",
+      },
     },
     output: {
       element: {
@@ -149,6 +153,10 @@ export const ja = {
       alert: {
         title: 'role="alert"',
         desc: '時間に敏感な重要情報を伝えるロール。aria-live="assertive" と似た挙動です。',
+      },
+      alertVisibility: {
+        title: "表示切り替えで現れる alert",
+        desc: "ページ読み込み時から DOM に存在し、display:none で隠されている alert 要素です。表示を切り替えて見せるのはフォームエラーなどでよくあるパターンで、スクリーンリーダーは要素が表示されたときに内容を読み上げます。",
       },
     },
     output: {


### PR DESCRIPTION
## 概要

Web開発者が実際に書きがちなアクセシビリティ上問題のあるパターンを、websiteのテストページに追加しました。ブラウザ拡張の挙動確認・回帰確認に使えるサンプルです。

## 追加したサンプル

### 見出し（Headings）
- ⚠️ `aria-level` のない `role="heading"`（仕様上はデフォルトでレベル2として扱われる）
- ⚠️ `<h2 aria-level="4">`（ARIA属性がタグ本来のレベルを上書きし、レベル4として扱われる）

### ライブリージョン（Live Regions）
- ページ読み込み時からDOMに存在し `display:none` で隠されている `role="alert"` 要素を、ボタンで表示/非表示に切り替えるサンプル（フォームエラーなどで頻出のパターン）

### フォームコントロール（Form Controls）
- ❌ `for` 属性が存在しないIDを参照しつつ、コントロールを内包している `<label>`（`for` が解決できない場合、内包コントロールへの関連付けは行われない）

## 備考

- en/ja両方の言語ファイルを更新済み
- `pnpm lint-fix` 通過、`pnpm build:website` でビルド成功・生成HTMLに反映されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)