### PR TITLE
perf: 複雑なWebアプリケーションでの描画パフォーマンスを改善

### DIFF
--- a/.changeset/perf-reduce-rendering-cost.md
+++ b/.changeset/perf-reduce-rendering-cost.md
@@ -4,7 +4,7 @@
 
 Improve rendering performance on complex web applications:
 
-- Stop re-collecting and re-evaluating the whole page on every mouse move. DOM changes are still detected by the MutationObserver.
+- Stop re-collecting and re-evaluating the whole page on every mouse move. Pointer-driven re-collection now happens only when the element under the pointer changes (`mouseover`/`mouseout`), which still picks up CSS `:hover`-driven UI such as dropdown menus.
 - Throttle pointer-tracking updates in interactive mode with `requestAnimationFrame`, and memoize each tip so only tips whose hover state changed re-render.
 - Use stable React keys based on the target element, avoiding unnecessary unmount/remount of tips when the collected list shifts.
 - Share the language setting across all tips through a single store, instead of reading extension storage and registering a listener per tip.

--- a/.changeset/perf-reduce-rendering-cost.md
+++ b/.changeset/perf-reduce-rendering-cost.md
@@ -1,0 +1,11 @@
+---
+"@a11y-visualizer/browser-extension": patch
+---
+
+Improve rendering performance on complex web applications:
+
+- Stop re-collecting and re-evaluating the whole page on every mouse move. DOM changes are still detected by the MutationObserver.
+- Throttle pointer-tracking updates in interactive mode with `requestAnimationFrame`, and memoize each tip so only tips whose hover state changed re-render.
+- Use stable React keys based on the target element, avoiding unnecessary unmount/remount of tips when the collected list shifts.
+- Share the language setting across all tips through a single store, instead of reading extension storage and registering a listener per tip.
+- Skip scroll-container lookup (which walks ancestors with `getComputedStyle`) for elements outside the viewport, and cache lookup results within a collection pass.

--- a/apps/browser_extension/entrypoints/all-frames.content/AllFramesRoot.tsx
+++ b/apps/browser_extension/entrypoints/all-frames.content/AllFramesRoot.tsx
@@ -167,14 +167,9 @@ export const AllFramesRoot = ({
 
     const resizeEvents = ["resize"];
     const scrollEvents = ["scroll"];
-    const events = [
-      "scroll",
-      "keydown",
-      "mousedown",
-      "mousemove",
-      "mousewheel",
-      "change",
-    ];
+    // mousemoveは含めない。マウス移動だけでページ全体の再収集が走って
+    // しまうため。hoverなどによるDOMの変化はMutationObserverが検知する
+    const events = ["scroll", "keydown", "mousedown", "mousewheel", "change"];
 
     resizeEvents.forEach((event) => {
       w.addEventListener(event, onResize);

--- a/apps/browser_extension/entrypoints/all-frames.content/AllFramesRoot.tsx
+++ b/apps/browser_extension/entrypoints/all-frames.content/AllFramesRoot.tsx
@@ -167,9 +167,19 @@ export const AllFramesRoot = ({
 
     const resizeEvents = ["resize"];
     const scrollEvents = ["scroll"];
-    // mousemoveは含めない。マウス移動だけでページ全体の再収集が走って
-    // しまうため。hoverなどによるDOMの変化はMutationObserverが検知する
-    const events = ["scroll", "keydown", "mousedown", "mousewheel", "change"];
+    // mousemoveは含めない。ポインタが同じ要素の上で動くだけでもページ全体の
+    // 再収集が走ってしまうため。:hoverで表示されるメニューなどDOMの変化を
+    // 伴わないCSSだけの変化はMutationObserverでは検知できないので、要素の
+    // 境界をまたいだときだけ発火するmouseover/mouseoutで再収集する
+    const events = [
+      "scroll",
+      "keydown",
+      "mousedown",
+      "mouseover",
+      "mouseout",
+      "mousewheel",
+      "change",
+    ];
 
     resizeEvents.forEach((event) => {
       w.addEventListener(event, onResize);

--- a/apps/browser_extension/entrypoints/content/components/ElementInfo.tsx
+++ b/apps/browser_extension/entrypoints/content/components/ElementInfo.tsx
@@ -6,7 +6,10 @@ import type { ElementMeta } from "../types";
 import { RuleTip } from "./RuleTip";
 
 const TIP_SIDE_MARGIN = 8;
-export const ElementInfo = ({
+// インタラクティブモードではポインタ移動のたびに親が再レンダリングされる
+// ため、メモ化してprops(メタ情報とホバー状態)が変わらないチップの
+// 再レンダリングを省略する
+export const ElementInfo = React.memo(function ElementInfo({
   meta: {
     x,
     y,
@@ -26,7 +29,7 @@ export const ElementInfo = ({
   rootWidth: number;
   rootHeight: number;
   isHovered: boolean;
-}) => {
+}) {
   const { interactiveMode, hideTips, tipFontSize, ...settings } =
     React.useContext(SettingsContext);
   const selfRef = React.useRef<HTMLDivElement>(null);
@@ -145,4 +148,4 @@ export const ElementInfo = ({
       </div>
     </div>
   );
-};
+});

--- a/apps/browser_extension/entrypoints/content/components/ElementList.tsx
+++ b/apps/browser_extension/entrypoints/content/components/ElementList.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import root from "react-shadow";
+import { getElementKey } from "../../../src/utils/getElementKey";
+import { rafThrottle } from "../../../src/utils/rafThrottle";
 import { SettingsContext } from "../contexts/SettingsContext";
 import type { ElementMeta } from "../types";
 import { ElementInfo } from "./ElementInfo";
@@ -53,42 +55,45 @@ export const ElementList = ({
       const win = node?.ownerDocument?.defaultView;
       if (!win) return;
 
+      // 高頻度イベントによる全チップの再レンダリングを1フレーム1回に抑える
+      const updateCoordinates = rafThrottle(
+        (coordinates: { x: number; y: number }[]) =>
+          setUserCoordinates(coordinates),
+      );
+      const clearCoordinates = () => {
+        updateCoordinates.cancel();
+        setUserCoordinates([]);
+      };
+      const touchesToCoordinates = (touches: TouchList) =>
+        Array.from(touches).map((touch) => ({
+          x: touch.pageX,
+          y: touch.pageY,
+        }));
+
       const handleMouseMove = (e: MouseEvent) => {
-        setUserCoordinates([{ x: e.pageX, y: e.pageY }]);
+        updateCoordinates([{ x: e.pageX, y: e.pageY }]);
       };
 
       const handleTouchStart = (e: TouchEvent) => {
-        const coordinates = Array.from(e.touches).map((touch) => ({
-          x: touch.pageX,
-          y: touch.pageY,
-        }));
-        setUserCoordinates(coordinates);
+        updateCoordinates(touchesToCoordinates(e.touches));
       };
 
       const handleTouchMove = (e: TouchEvent) => {
-        const coordinates = Array.from(e.touches).map((touch) => ({
-          x: touch.pageX,
-          y: touch.pageY,
-        }));
-        setUserCoordinates(coordinates);
+        updateCoordinates(touchesToCoordinates(e.touches));
       };
 
       const handleTouchEnd = (e: TouchEvent) => {
         // When touchend occurs, e.touches is empty, so we need to check if there are any remaining touches
         if (e.touches.length === 0) {
-          setUserCoordinates([]);
+          clearCoordinates();
         } else {
           // Some touches remaining, update with current touches
-          const coordinates = Array.from(e.touches).map((touch) => ({
-            x: touch.pageX,
-            y: touch.pageY,
-          }));
-          setUserCoordinates(coordinates);
+          updateCoordinates(touchesToCoordinates(e.touches));
         }
       };
       const handleMouseOut = (e: MouseEvent) => {
         if (!e.relatedTarget) {
-          setUserCoordinates([]);
+          clearCoordinates();
         }
       };
 
@@ -104,6 +109,7 @@ export const ElementList = ({
         win.addEventListener("touchend", handleTouchEnd, { passive: true });
       }
       cleanupRef.current = () => {
+        updateCoordinates.cancel();
         try {
           win.removeEventListener("mousemove", handleMouseMove);
           win.document.removeEventListener("mouseout", handleMouseOut);
@@ -149,11 +155,10 @@ export const ElementList = ({
         }}
         ref={setCallbacks}
       >
-        {list.map((meta, i) => {
+        {list.map((meta) => {
           return (
             <ElementInfo
-              // biome-ignore lint/suspicious/noArrayIndexKey: collected elements have no stable id; index is combined with category and name
-              key={`${i}-${meta.category}-${meta.name}`}
+              key={getElementKey(meta.element)}
               meta={meta}
               rootHeight={height}
               rootWidth={width}

--- a/apps/browser_extension/entrypoints/content/dom/collectElements.ts
+++ b/apps/browser_extension/entrypoints/content/dom/collectElements.ts
@@ -65,6 +65,8 @@ export const collectElements = (
 
   const selector = getSelector(settings);
   const internalTables: Table[] = [];
+  // 同じ祖先を持つ要素間でスクロール基準の判定結果を使い回す
+  const scrollBaseCache = new WeakMap<Element, Element | null>();
 
   // Shadow DOMを収集
   const shadowRoots = collectShadowRoots(root);
@@ -100,10 +102,6 @@ export const collectElements = (
       return true;
     })
     .map((el: Element) => {
-      const scrollBaseElement = getScrollBaseElement(el, d, w);
-      const scrollBasePosition = scrollBaseElement
-        ? getElementPosition(scrollBaseElement, w, 0, 0)
-        : undefined;
       const elementPosition = getElementPosition(el, w, offsetX, offsetY);
       if (
         elementPosition.absoluteX + elementPosition.width < visibleX ||
@@ -113,6 +111,12 @@ export const collectElements = (
       ) {
         return null;
       }
+      // スクロール基準の探索は祖先のgetComputedStyleを伴い高コストなので、
+      // ビューポートによる絞り込みを通過した要素にだけ行う
+      const scrollBaseElement = getScrollBaseElement(el, d, w, scrollBaseCache);
+      const scrollBasePosition = scrollBaseElement
+        ? getElementPosition(scrollBaseElement, w, 0, 0)
+        : undefined;
       if (
         scrollBasePosition &&
         (elementPosition.absoluteX + elementPosition.width <
@@ -152,6 +156,7 @@ export const collectElements = (
 
       return {
         ...elementPosition,
+        element: el,
         rects,
         name: name || "",
         category: getElementCategory(el, role),

--- a/apps/browser_extension/entrypoints/content/dom/getScrollBaseElement.test.ts
+++ b/apps/browser_extension/entrypoints/content/dom/getScrollBaseElement.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { getScrollBaseElement } from "./getScrollBaseElement";
+
+describe("getScrollBaseElement()", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  test("スクロール可能な祖先要素を返す", () => {
+    document.body.innerHTML = `
+      <div id="scrollable" style="overflow-y: auto; height: 100px;">
+        <div><span id="target">target</span></div>
+      </div>
+    `;
+    const target = document.getElementById("target") as Element;
+    const scrollable = document.getElementById("scrollable");
+    expect(getScrollBaseElement(target)).toBe(scrollable);
+  });
+
+  test("要素自身がスクロール可能な場合は自身を返す", () => {
+    document.body.innerHTML = `
+      <div id="target" style="overflow-x: scroll;">target</div>
+    `;
+    const target = document.getElementById("target") as Element;
+    expect(getScrollBaseElement(target)).toBe(target);
+  });
+
+  test("スクロール可能な祖先がない場合はundefinedを返す", () => {
+    document.body.innerHTML = `
+      <div><span id="target">target</span></div>
+    `;
+    const target = document.getElementById("target") as Element;
+    expect(getScrollBaseElement(target)).toBeUndefined();
+  });
+
+  test("body要素にはundefinedを返す", () => {
+    expect(getScrollBaseElement(document.body)).toBeUndefined();
+  });
+
+  test("キャッシュがある場合、2回目以降はgetComputedStyleを呼ばない", () => {
+    document.body.innerHTML = `
+      <div id="scrollable" style="overflow-y: auto; height: 100px;">
+        <div><span id="target">target</span></div>
+      </div>
+    `;
+    const target = document.getElementById("target") as Element;
+    const scrollable = document.getElementById("scrollable");
+    const cache = new WeakMap<Element, Element | null>();
+    const spy = vi.spyOn(window, "getComputedStyle");
+
+    expect(getScrollBaseElement(target, document, window, cache)).toBe(
+      scrollable,
+    );
+    const callsAfterFirst = spy.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+
+    expect(getScrollBaseElement(target, document, window, cache)).toBe(
+      scrollable,
+    );
+    expect(spy.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  test("スクロール基準がない結果もキャッシュされる", () => {
+    document.body.innerHTML = `
+      <div><span id="target">target</span></div>
+    `;
+    const target = document.getElementById("target") as Element;
+    const cache = new WeakMap<Element, Element | null>();
+    const spy = vi.spyOn(window, "getComputedStyle");
+
+    expect(
+      getScrollBaseElement(target, document, window, cache),
+    ).toBeUndefined();
+    const callsAfterFirst = spy.mock.calls.length;
+
+    expect(
+      getScrollBaseElement(target, document, window, cache),
+    ).toBeUndefined();
+    expect(spy.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  test("同じキャッシュを使うと祖先の判定結果が再利用される", () => {
+    document.body.innerHTML = `
+      <div id="scrollable" style="overflow-y: auto; height: 100px;">
+        <div id="parent">
+          <span id="target1">target1</span>
+          <span id="target2">target2</span>
+        </div>
+      </div>
+    `;
+    const target1 = document.getElementById("target1") as Element;
+    const target2 = document.getElementById("target2") as Element;
+    const scrollable = document.getElementById("scrollable");
+    const cache = new WeakMap<Element, Element | null>();
+    const spy = vi.spyOn(window, "getComputedStyle");
+
+    expect(getScrollBaseElement(target1, document, window, cache)).toBe(
+      scrollable,
+    );
+    const callsAfterFirst = spy.mock.calls.length;
+
+    // target2自身の分だけgetComputedStyleが増える(祖先はキャッシュ済み)
+    expect(getScrollBaseElement(target2, document, window, cache)).toBe(
+      scrollable,
+    );
+    expect(spy.mock.calls.length).toBe(callsAfterFirst + 1);
+  });
+});

--- a/apps/browser_extension/entrypoints/content/dom/getScrollBaseElement.ts
+++ b/apps/browser_extension/entrypoints/content/dom/getScrollBaseElement.ts
@@ -1,17 +1,39 @@
+/**
+ * 要素のスクロール基準となる祖先要素(overflowがauto/scrollの要素)を取得する
+ *
+ * @param el - 対象の要素
+ * @param d - 要素が属するDocument
+ * @param w - 要素が属するWindow
+ * @param cache - 判定結果のキャッシュ。同一の収集パス内で使い回すと、
+ *   同じ祖先を持つ要素間でgetComputedStyleの再計算を省略できる。
+ *   スクロール基準がない場合はnullとして保存される
+ * @returns スクロール基準となる要素。ない場合はundefined
+ */
 export const getScrollBaseElement = (
   el: Element,
   d = el.ownerDocument,
   w = d.defaultView,
+  cache?: WeakMap<Element, Element | null>,
 ): Element | undefined => {
   if (!w) return undefined;
-  const style = w.getComputedStyle(el);
-  const { overflowX, overflowY } = style;
-  if (el === d.body) return undefined;
-  if (
-    ["auto", "scroll"].includes(overflowX) ||
-    ["auto", "scroll"].includes(overflowY)
-  )
-    return el;
-  if (el.parentElement) return getScrollBaseElement(el.parentElement, d, w);
-  return undefined;
+  if (cache?.has(el)) return cache.get(el) ?? undefined;
+
+  let result: Element | undefined;
+  if (el === d.body) {
+    result = undefined;
+  } else {
+    const { overflowX, overflowY } = w.getComputedStyle(el);
+    if (
+      ["auto", "scroll"].includes(overflowX) ||
+      ["auto", "scroll"].includes(overflowY)
+    ) {
+      result = el;
+    } else if (el.parentElement) {
+      result = getScrollBaseElement(el.parentElement, d, w, cache);
+    } else {
+      result = undefined;
+    }
+  }
+  cache?.set(el, result ?? null);
+  return result;
 };

--- a/apps/browser_extension/entrypoints/content/types.ts
+++ b/apps/browser_extension/entrypoints/content/types.ts
@@ -2,6 +2,7 @@ import type { ElementPosition } from "@a11y-visualizer/dom-utils";
 import type { RuleResult } from "@a11y-visualizer/rules";
 
 export type ElementMeta = {
+  element: Element;
   name: string;
   category: Category;
   ruleResults: RuleResult[];

--- a/apps/browser_extension/src/useLang.ts
+++ b/apps/browser_extension/src/useLang.ts
@@ -4,6 +4,7 @@ import { browser } from "#imports";
 import i18n from "./i18n";
 import { loadDefaultSettings } from "./settings";
 import type { Settings, SupportedLanguage } from "./settings/types";
+import { createExternalStore } from "./utils/createExternalStore";
 
 const getLanguageFromBrowser = (): SupportedLanguage => {
   const browserLang = browser.i18n.getUILanguage();
@@ -19,46 +20,53 @@ const resolveLanguage = (settingLang: SupportedLanguage): SupportedLanguage => {
   return settingLang;
 };
 
-export const useLang = () => {
-  const [lang, setLang] = React.useState<string>("en");
+// 言語の状態はモジュールスコープで一元管理する。useLangはチップごとなど
+// 多数のコンポーネントから呼ばれるため、フックのマウントごとにストレージの
+// 読み込みやリスナー登録を行うと重い
+const langStore = createExternalStore<string>("en");
+let langInitialized = false;
 
-  React.useEffect(() => {
-    loadDefaultSettings().then(([settings]) => {
-      const resolvedLang = resolveLanguage(settings.language);
-      setLang(resolvedLang);
-      i18n.changeLanguage(resolvedLang);
-    });
+const applyLanguage = (settingLang: SupportedLanguage) => {
+  const resolvedLang = resolveLanguage(settingLang);
+  langStore.set(resolvedLang);
+  i18n.changeLanguage(resolvedLang);
+};
 
-    // ストレージ変更の監視
-    const handleStorageChange = (
-      changes: Record<string, { newValue?: unknown; oldValue?: unknown }>,
-    ) => {
-      if (changes.__default__?.newValue) {
-        const newSettings = changes.__default__.newValue as Settings;
-        if (newSettings.language) {
-          const resolvedLang = resolveLanguage(newSettings.language);
-          setLang(resolvedLang);
-          i18n.changeLanguage(resolvedLang);
-        }
+const initializeLang = () => {
+  if (langInitialized) return;
+  langInitialized = true;
+
+  loadDefaultSettings().then(([settings]) => {
+    applyLanguage(settings.language);
+  });
+
+  // ストレージ変更の監視
+  const handleStorageChange = (
+    changes: Record<string, { newValue?: unknown; oldValue?: unknown }>,
+  ) => {
+    if (changes.__default__?.newValue) {
+      const newSettings = changes.__default__.newValue as Settings;
+      if (newSettings.language) {
+        applyLanguage(newSettings.language);
       }
-    };
+    }
+  };
+  browser.storage.local.onChanged.addListener(handleStorageChange);
+};
 
-    browser.storage.local.onChanged.addListener(handleStorageChange);
-
-    return () => {
-      browser.storage.local.onChanged.removeListener(handleStorageChange);
-    };
+export const useLang = () => {
+  React.useEffect(() => {
+    initializeLang();
   }, []);
 
+  const lang = React.useSyncExternalStore(langStore.subscribe, langStore.get);
   const { t } = useTranslation();
 
   return {
     t,
     lang,
     updateLanguage: (newLang: SupportedLanguage) => {
-      const resolvedLang = resolveLanguage(newLang);
-      setLang(resolvedLang);
-      i18n.changeLanguage(resolvedLang);
+      applyLanguage(newLang);
     },
   };
 };

--- a/apps/browser_extension/src/utils/createExternalStore.test.ts
+++ b/apps/browser_extension/src/utils/createExternalStore.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, vi } from "vitest";
+import { createExternalStore } from "./createExternalStore";
+
+describe("createExternalStore()", () => {
+  test("初期値を取得できる", () => {
+    const store = createExternalStore("en");
+    expect(store.get()).toBe("en");
+  });
+
+  test("値を更新すると購読者に通知される", () => {
+    const store = createExternalStore("en");
+    const listener = vi.fn();
+    store.subscribe(listener);
+    store.set("ja");
+    expect(store.get()).toBe("ja");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  test("同じ値をセットしても通知されない", () => {
+    const store = createExternalStore("en");
+    const listener = vi.fn();
+    store.subscribe(listener);
+    store.set("en");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test("購読解除すると通知されなくなる", () => {
+    const store = createExternalStore("en");
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe(listener);
+    unsubscribe();
+    store.set("ja");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test("複数の購読者に通知される", () => {
+    const store = createExternalStore(0);
+    const listener1 = vi.fn();
+    const listener2 = vi.fn();
+    store.subscribe(listener1);
+    store.subscribe(listener2);
+    store.set(1);
+    expect(listener1).toHaveBeenCalledTimes(1);
+    expect(listener2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/browser_extension/src/utils/createExternalStore.ts
+++ b/apps/browser_extension/src/utils/createExternalStore.ts
@@ -1,0 +1,36 @@
+export type ExternalStore<T> = {
+  get: () => T;
+  set: (newValue: T) => void;
+  subscribe: (listener: () => void) => () => void;
+};
+
+/**
+ * React.useSyncExternalStoreで購読できる単純なストアを作成する
+ *
+ * モジュールスコープで状態を一元管理し、多数のコンポーネントから
+ * 参照される値(言語設定など)を、コンポーネントごとの読み込みや
+ * リスナー登録なしで共有するために使う
+ *
+ * @param initialValue - 初期値
+ * @returns 値の取得・更新・購読ができるストア
+ */
+export const createExternalStore = <T>(initialValue: T): ExternalStore<T> => {
+  let value = initialValue;
+  const listeners = new Set<() => void>();
+  return {
+    get: () => value,
+    set: (newValue: T) => {
+      if (Object.is(newValue, value)) return;
+      value = newValue;
+      for (const listener of [...listeners]) {
+        listener();
+      }
+    },
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+};

--- a/apps/browser_extension/src/utils/getElementKey.test.ts
+++ b/apps/browser_extension/src/utils/getElementKey.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { getElementKey } from "./getElementKey";
+
+describe("getElementKey()", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("同じ要素には常に同じキーを返す", () => {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    const key1 = getElementKey(element);
+    const key2 = getElementKey(element);
+    expect(key1).toBe(key2);
+  });
+
+  test("異なる要素には異なるキーを返す", () => {
+    const element1 = document.createElement("div");
+    const element2 = document.createElement("div");
+    document.body.appendChild(element1);
+    document.body.appendChild(element2);
+    expect(getElementKey(element1)).not.toBe(getElementKey(element2));
+  });
+
+  test("DOMから切り離された後も同じキーを返す", () => {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    const key1 = getElementKey(element);
+    element.remove();
+    expect(getElementKey(element)).toBe(key1);
+  });
+});

--- a/apps/browser_extension/src/utils/getElementKey.ts
+++ b/apps/browser_extension/src/utils/getElementKey.ts
@@ -1,0 +1,22 @@
+const elementKeys = new WeakMap<Element, number>();
+let nextElementKey = 0;
+
+/**
+ * 要素に対して安定したキーを発行する
+ *
+ * 同じ要素には常に同じキーを返す。要素の収集のたびに作り直される
+ * ElementMetaをReactのkeyで安定的に要素へ対応付け、不要な
+ * unmount/remountを防ぐために使う
+ *
+ * @param element - 対象の要素
+ * @returns 要素に対応するキー
+ */
+export const getElementKey = (element: Element): number => {
+  let key = elementKeys.get(element);
+  if (key === undefined) {
+    key = nextElementKey;
+    nextElementKey += 1;
+    elementKeys.set(element, key);
+  }
+  return key;
+};

--- a/apps/browser_extension/src/utils/rafThrottle.test.ts
+++ b/apps/browser_extension/src/utils/rafThrottle.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { rafThrottle } from "./rafThrottle";
+
+describe("rafThrottle()", () => {
+  let rafCallbacks: Map<number, FrameRequestCallback>;
+  let rafId: number;
+
+  const flushAnimationFrames = () => {
+    const callbacks = [...rafCallbacks.values()];
+    rafCallbacks.clear();
+    for (const callback of callbacks) {
+      callback(0);
+    }
+  };
+
+  beforeEach(() => {
+    rafCallbacks = new Map();
+    rafId = 0;
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (callback: FrameRequestCallback): number => {
+        rafId += 1;
+        rafCallbacks.set(rafId, callback);
+        return rafId;
+      },
+    );
+    vi.stubGlobal("cancelAnimationFrame", (id: number): void => {
+      rafCallbacks.delete(id);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("フレームが来るまで実行されない", () => {
+    const fn = vi.fn();
+    const throttled = rafThrottle(fn);
+    throttled(1);
+    expect(fn).not.toHaveBeenCalled();
+    flushAnimationFrames();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(1);
+  });
+
+  test("1フレーム内の複数回の呼び出しは、最後の引数で1回だけ実行される", () => {
+    const fn = vi.fn();
+    const throttled = rafThrottle(fn);
+    throttled(1);
+    throttled(2);
+    throttled(3);
+    flushAnimationFrames();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(3);
+  });
+
+  test("フレームの後は再度スケジュールできる", () => {
+    const fn = vi.fn();
+    const throttled = rafThrottle(fn);
+    throttled(1);
+    flushAnimationFrames();
+    throttled(2);
+    flushAnimationFrames();
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith(2);
+  });
+
+  test("cancel()で保留中の実行をキャンセルできる", () => {
+    const fn = vi.fn();
+    const throttled = rafThrottle(fn);
+    throttled(1);
+    throttled.cancel();
+    flushAnimationFrames();
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test("cancel()の後も再度スケジュールできる", () => {
+    const fn = vi.fn();
+    const throttled = rafThrottle(fn);
+    throttled(1);
+    throttled.cancel();
+    throttled(2);
+    flushAnimationFrames();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(2);
+  });
+});

--- a/apps/browser_extension/src/utils/rafThrottle.ts
+++ b/apps/browser_extension/src/utils/rafThrottle.ts
@@ -1,0 +1,40 @@
+export type RafThrottled<Args extends unknown[]> = ((...args: Args) => void) & {
+  cancel: () => void;
+};
+
+/**
+ * 関数の呼び出しをrequestAnimationFrameで間引く
+ *
+ * 1フレーム内に複数回呼び出された場合、最後の引数で1回だけ実行する。
+ * mousemoveなどの高頻度イベントによる再レンダリングを抑えるために使う
+ *
+ * @param fn - 間引いて実行する関数
+ * @returns 間引かれた関数。`cancel()`で保留中の実行をキャンセルできる
+ */
+export const rafThrottle = <Args extends unknown[]>(
+  fn: (...args: Args) => void,
+): RafThrottled<Args> => {
+  let rafId: number | null = null;
+  let lastArgs: Args | null = null;
+
+  const throttled = (...args: Args) => {
+    lastArgs = args;
+    if (rafId !== null) return;
+    rafId = requestAnimationFrame(() => {
+      rafId = null;
+      if (lastArgs) {
+        fn(...lastArgs);
+      }
+    });
+  };
+
+  throttled.cancel = () => {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    lastArgs = null;
+  };
+
+  return throttled;
+};


### PR DESCRIPTION
## 概要

複雑なWebアプリケーションでチップ表示を有効にしていると描画に時間がかかる問題への対策として、「収集処理の実行頻度」と「React側の再レンダリング量」を削減します。

## 変更内容

### 収集処理の頻度削減
- **mousemoveイベントでのページ全体の再収集を廃止**(`AllFramesRoot.tsx`)。ポインタが同じ要素の上で動いているだけで200msごとにフルスキャンが走っていたのをなくしました。ポインタ起因の再収集は、要素の境界をまたいだときだけ発火する`mouseover`/`mouseout`で行うため、`:hover`だけで表示されるドロップダウンメニューなどのCSSだけの変化も引き続き検知できます。DOMの変化は従来どおりMutationObserverが検知します。

### React側の再レンダリング抑制
- インタラクティブモードの座標更新を`requestAnimationFrame`で間引き(新設`rafThrottle`)。タッチ終了・マウスアウト時は保留中の更新をキャンセルしてから即クリアします。
- `ElementInfo`を`React.memo`化し、ポインタ移動時はホバー状態が変わったチップだけを再レンダリング。
- Reactのkeyを「インデックス+カテゴリ+名前」から要素参照ベースの安定キー(新設`getElementKey`)に変更し、収集結果の順序が変わった際の不要なunmount/remountを防止。`ElementMeta`に`element`フィールドを追加しています(フレーム外には送信されません)。
- `useLang`の言語状態をモジュールレベルの共有ストア(新設`createExternalStore` + `useSyncExternalStore`)で一元管理。従来はチップ1個ごとに発生していたストレージ読み込みと`storage.onChanged`リスナー登録が、全体で1回になります。

### 収集処理そのものの軽量化
- `collectElements`で、スクロール基準の探索(祖先を`getComputedStyle`で遡る処理)をビューポートによる絞り込みの通過後にのみ実行するよう移動。
- 同一収集パス内で`getScrollBaseElement`の判定結果をWeakMapキャッシュで共有し、同じ祖先チェーンの再計算を省略。

## テスト

- 新規ユーティリティ3つと`getScrollBaseElement`のキャッシュ動作にテストを追加(+20件)
- `pnpm test`(chromium / firefox): 470件すべて通過
- `pnpm compile` / `pnpm lint`: 通過
- jsdomテストの既存失敗(レイアウト依存のtarget-size等、6ファイル/10件)は変更前後で増減なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
