### PR TITLE
テストページにターゲットサイズのサンプルを追加

### DIFF
--- a/apps/website/src/components/tests/TargetSizeTests.astro
+++ b/apps/website/src/components/tests/TargetSizeTests.astro
@@ -1,0 +1,171 @@
+---
+import { createLocalT } from "../../lib/i18n";
+import CategorySectionTitle from "./CategorySectionTitle.astro";
+import CategoryTitle from "./CategoryTitle.astro";
+import ExampleCard from "./ExampleCard.astro";
+import { en, ja } from "./TargetSizeTests.lang";
+
+interface Props {
+  lang?: string;
+}
+const lang = (Astro.props as Props).lang || "en";
+const t = createLocalT(lang === "ja" ? ja : en, en);
+
+// Base button style without a fixed size, so each example can set its own size.
+const btnBase =
+  "bg-teal-700 text-white rounded-md inline-flex items-center justify-center cursor-pointer hover:bg-teal-800 transition-colors leading-none";
+---
+
+<CategoryTitle id="target-size">{t("title")}</CategoryTitle>
+<p class="text-zinc-700 dark:text-zinc-300 mb-6">{t("intro")}</p>
+
+<CategorySectionTitle id="single-target"
+  >{t("sections.singleTarget.title")}</CategorySectionTitle
+>
+
+<ExampleCard
+  title={t("examples.standard.title")}
+  description={t("examples.standard.desc")}
+>
+  <button
+    type="button"
+    class={`${btnBase} h-11 px-4`}
+    onclick="window.alert('Hello!')">設定</button
+  >
+</ExampleCard>
+
+<ExampleCard
+  title={t("examples.minimum.title")}
+  description={t("examples.minimum.desc")}
+>
+  <button
+    type="button"
+    class={btnBase}
+    style="width:24px;height:24px;font-size:14px"
+    aria-label="お気に入り"
+    onclick="window.alert('Hello!')">♥</button
+  >
+</ExampleCard>
+
+<ExampleCard
+  title={t("examples.tooSmall.title")}
+  description={t("examples.tooSmall.desc")}
+>
+  <button
+    type="button"
+    class={btnBase}
+    style="width:16px;height:16px;font-size:10px"
+    aria-label="削除"
+    onclick="window.alert('Hello!')">✕</button
+  >
+</ExampleCard>
+
+<CategorySectionTitle id="target-spacing"
+  >{t("sections.spacing.title")}</CategorySectionTitle
+>
+
+<ExampleCard
+  title={t("examples.dense.title")}
+  description={t("examples.dense.desc")}
+>
+  <div class="flex">
+    <button
+      type="button"
+      class={btnBase}
+      style="width:20px;height:20px;font-size:12px"
+      aria-label="ダイヤ"
+      onclick="window.alert('Hello!')">◆</button
+    >
+    <button
+      type="button"
+      class={btnBase}
+      style="width:20px;height:20px;font-size:12px"
+      aria-label="スペード"
+      onclick="window.alert('Hello!')">♠</button
+    >
+    <button
+      type="button"
+      class={btnBase}
+      style="width:20px;height:20px;font-size:12px"
+      aria-label="ハート"
+      onclick="window.alert('Hello!')">❤</button
+    >
+    <button
+      type="button"
+      class={btnBase}
+      style="width:20px;height:20px;font-size:12px"
+      aria-label="クラブ"
+      onclick="window.alert('Hello!')">♣</button
+    >
+    <button
+      type="button"
+      class={btnBase}
+      style="width:20px;height:20px;font-size:12px"
+      aria-label="スター"
+      onclick="window.alert('Hello!')">★</button
+    >
+  </div>
+</ExampleCard>
+
+<ExampleCard
+  title={t("examples.adjacent.title")}
+  description={t("examples.adjacent.desc")}
+>
+  <div class="flex items-center">
+    <button
+      type="button"
+      class={`${btnBase} h-11 px-4`}
+      onclick="window.alert('Hello!')">保存</button
+    >
+    <button
+      type="button"
+      class={btnBase}
+      style="width:16px;height:16px;font-size:10px"
+      aria-label="キャンセル"
+      onclick="window.alert('Hello!')">✕</button
+    >
+  </div>
+</ExampleCard>
+
+<ExampleCard
+  title={t("examples.mitigated.title")}
+  description={t("examples.mitigated.desc")}
+>
+  <div class="flex gap-3">
+    <button
+      type="button"
+      class={btnBase}
+      style="width:20px;height:20px;font-size:12px"
+      aria-label="ダイヤ"
+      onclick="window.alert('Hello!')">◆</button
+    >
+    <button
+      type="button"
+      class={btnBase}
+      style="width:20px;height:20px;font-size:12px"
+      aria-label="スペード"
+      onclick="window.alert('Hello!')">♠</button
+    >
+    <button
+      type="button"
+      class={btnBase}
+      style="width:20px;height:20px;font-size:12px"
+      aria-label="ハート"
+      onclick="window.alert('Hello!')">❤</button
+    >
+    <button
+      type="button"
+      class={btnBase}
+      style="width:20px;height:20px;font-size:12px"
+      aria-label="クラブ"
+      onclick="window.alert('Hello!')">♣</button
+    >
+    <button
+      type="button"
+      class={btnBase}
+      style="width:20px;height:20px;font-size:12px"
+      aria-label="スター"
+      onclick="window.alert('Hello!')">★</button
+    >
+  </div>
+</ExampleCard>

--- a/apps/website/src/components/tests/TargetSizeTests.lang.ts
+++ b/apps/website/src/components/tests/TargetSizeTests.lang.ts
@@ -1,0 +1,71 @@
+export const en = {
+  title: "Target Size",
+  intro:
+    "Interactive targets such as buttons and links need to be large enough, and spaced far enough apart, to be operated comfortably by touch and pointer users. WCAG 2.5.8 (AA) requires a minimum target size of 24×24 CSS pixels, and WCAG 2.5.5 (AAA) recommends at least 44×44 CSS pixels. Undersized targets can still pass if there is enough spacing around them. The following examples use buttons to show target size and spacing patterns.",
+  sections: {
+    singleTarget: { title: "Single Target Size" },
+    spacing: { title: "Spacing Between Targets" },
+  },
+  examples: {
+    standard: {
+      title: "Comfortably sized button (44×44px)",
+      desc: "✅ A button at least 44×44 CSS pixels. This meets the AAA recommendation (WCAG 2.5.5) and is easy to operate for touch and pointer users.",
+    },
+    minimum: {
+      title: "Minimum sized button (24×24px)",
+      desc: "⚠️ A 24×24 CSS pixel button meets the AA minimum (WCAG 2.5.8) but is on the edge. A larger target of 44×44px is recommended for comfortable operation.",
+    },
+    tooSmall: {
+      title: "Too small button (16×16px)",
+      desc: "❌ A 16×16 CSS pixel button is below the 24×24px minimum. It is hard to tap accurately and fails WCAG 2.5.8.",
+    },
+    dense: {
+      title: "Too small buttons packed together",
+      desc: "❌ Several undersized buttons placed right next to each other with no spacing. Each target is too small and too close to its neighbors, making them easy to mis-tap.",
+    },
+    adjacent: {
+      title: "Large and small buttons adjacent",
+      desc: "❌ A large button next to a small button with no spacing. Even though one target is large, the small one is undersized and sits too close, so it is easy to activate the wrong one.",
+    },
+    mitigated: {
+      title: "Adequate spacing around small targets",
+      desc: "✅ The same small buttons, but with enough spacing that a 24px circle centered on each target does not overlap its neighbors. This satisfies the WCAG 2.5.8 spacing exception. Making the targets 44×44px is still preferable.",
+    },
+  },
+} as const;
+
+export const ja = {
+  title: "ターゲットサイズ",
+  intro:
+    "ボタンやリンクなどの操作ターゲットは、タッチやポインターで快適に操作できるよう、十分な大きさと間隔が必要です。WCAG 2.5.8（AA）は最小 24×24 CSS ピクセルを求め、WCAG 2.5.5（AAA）は 44×44 CSS ピクセル以上を推奨しています。小さいターゲットでも、周囲に十分な間隔があれば要件を満たせます。以下はボタンを使ってターゲットサイズと間隔のパターンを示します。",
+  sections: {
+    singleTarget: { title: "単体のターゲットサイズ" },
+    spacing: { title: "ターゲット間の間隔" },
+  },
+  examples: {
+    standard: {
+      title: "十分な大きさのボタン（44×44px）",
+      desc: "✅ 44×44 CSS ピクセル以上のボタン。AAA の推奨（WCAG 2.5.5）を満たし、タッチやポインターでも操作しやすい大きさです。",
+    },
+    minimum: {
+      title: "最小サイズのボタン（24×24px）",
+      desc: "⚠️ 24×24 CSS ピクセルのボタンは AA の最小要件（WCAG 2.5.8）を満たしますが、ぎりぎりの大きさです。快適な操作のためには 44×44px 以上を推奨します。",
+    },
+    tooSmall: {
+      title: "小さすぎるボタン（16×16px）",
+      desc: "❌ 16×16 CSS ピクセルのボタンは最小の 24×24px を下回っています。正確にタップしづらく、WCAG 2.5.8 を満たしません。",
+    },
+    dense: {
+      title: "小さすぎるボタンが密集した状態",
+      desc: "❌ 小さすぎるボタンを間隔なく並べたもの。ターゲットが小さいうえに隣接しているため、誤って隣を押しやすくなります。",
+    },
+    adjacent: {
+      title: "大きなボタンと小さなボタンが隣接した状態",
+      desc: "❌ 大きなボタンの隣に小さなボタンを間隔なく配置したもの。片方が大きくても、小さいほうはサイズ不足のうえ近すぎるため、意図しないボタンを押しやすくなります。",
+    },
+    mitigated: {
+      title: "小さいターゲットの間隔を確保した状態",
+      desc: "✅ 同じ小さいボタンでも、各ターゲットを中心とした直径 24px の円が隣と重ならないだけの間隔を空けたもの。WCAG 2.5.8 の間隔に関する例外を満たします。ターゲット自体を 44×44px にできればより望ましいです。",
+    },
+  },
+} as const;

--- a/apps/website/src/lib/testCategories.ts
+++ b/apps/website/src/lib/testCategories.ts
@@ -3,6 +3,7 @@ export const testCategories = [
   { slug: "images", dictKey: "images" },
   { slug: "links", dictKey: "links" },
   { slug: "buttons", dictKey: "buttons" },
+  { slug: "target-size", dictKey: "targetSize" },
   { slug: "form-controls", dictKey: "forms" },
   { slug: "layout", dictKey: "landmarks" },
   { slug: "lists", dictKey: "lists" },

--- a/apps/website/src/pages/ja/tests.lang.ts
+++ b/apps/website/src/pages/ja/tests.lang.ts
@@ -17,6 +17,7 @@ const dict = {
     headings: {
       images: "画像",
       buttons: "ボタン",
+      targetSize: "ターゲットサイズ",
       links: "リンク",
       forms: "フォームコントロール",
       headings: "見出し",

--- a/apps/website/src/pages/ja/tests/[category].astro
+++ b/apps/website/src/pages/ja/tests/[category].astro
@@ -13,6 +13,7 @@ import ListTests from "../../../components/tests/ListTests.astro";
 import LiveRegionTests from "../../../components/tests/LiveRegionTests.astro";
 import ShadowDomTests from "../../../components/tests/ShadowDomTests.astro";
 import TableTests from "../../../components/tests/TableTests.astro";
+import TargetSizeTests from "../../../components/tests/TargetSizeTests.astro";
 import Warning from "../../../components/tests/Warning.astro";
 import TestPageLayout from "../../../layouts/TestPageLayout.astro";
 import { createLocalT } from "../../../lib/i18n";
@@ -58,6 +59,7 @@ const categoryName = t(`categories.headings.${dictKey}`);
   {category === "images" && <ImageTests lang="ja" />}
   {category === "links" && <LinkTests lang="ja" />}
   {category === "buttons" && <ButtonTests lang="ja" />}
+  {category === "target-size" && <TargetSizeTests lang="ja" />}
   {category === "form-controls" && <FormControlTests lang="ja" />}
   {category === "layout" && <LayoutTests lang="ja" />}
   {category === "lists" && <ListTests lang="ja" />}

--- a/apps/website/src/pages/tests.lang.ts
+++ b/apps/website/src/pages/tests.lang.ts
@@ -17,6 +17,7 @@ const dict = {
     headings: {
       images: "Images",
       buttons: "Buttons",
+      targetSize: "Target Size",
       links: "Links",
       forms: "Form Controls",
       headings: "Headings",

--- a/apps/website/src/pages/tests/[category].astro
+++ b/apps/website/src/pages/tests/[category].astro
@@ -13,6 +13,7 @@ import ListTests from "../../components/tests/ListTests.astro";
 import LiveRegionTests from "../../components/tests/LiveRegionTests.astro";
 import ShadowDomTests from "../../components/tests/ShadowDomTests.astro";
 import TableTests from "../../components/tests/TableTests.astro";
+import TargetSizeTests from "../../components/tests/TargetSizeTests.astro";
 import Warning from "../../components/tests/Warning.astro";
 import TestPageLayout from "../../layouts/TestPageLayout.astro";
 import { createLocalT } from "../../lib/i18n";
@@ -57,6 +58,7 @@ const categoryName = t(`categories.headings.${dictKey}`);
   {category === "images" && <ImageTests lang="en" />}
   {category === "links" && <LinkTests lang="en" />}
   {category === "buttons" && <ButtonTests lang="en" />}
+  {category === "target-size" && <TargetSizeTests lang="en" />}
   {category === "form-controls" && <FormControlTests lang="en" />}
   {category === "layout" && <LayoutTests lang="en" />}
   {category === "lists" && <ListTests lang="en" />}


### PR DESCRIPTION
## 概要

テストページ（`apps/website`）に、ターゲットサイズをテーマにした新しいカテゴリー「ターゲットサイズ / Target Size」を追加しました。ボタンをターゲットの例として使用しています。

## サンプル内容

**単体のターゲットサイズ**
- ✅ 十分な大きさのボタン（44×44px、WCAG 2.5.5 AAA推奨）
- ⚠️ 最小サイズのボタン（24×24px、WCAG 2.5.8 AA最小）
- ❌ 小さすぎるボタン（16×16px）

**ターゲット間の間隔**
- ❌ 小さすぎるボタンが密集した状態
- ❌ 大きなボタンと小さなボタンが隣接した状態
- ✅ 小さいターゲットの間隔を確保した状態（WCAG 2.5.8 間隔例外）

アイコンボタンは ◆♠❤♣★ の異なる記号を使い、それぞれに `aria-label` を付与しています。

## 補足

- 現状、拡張機能側にターゲットサイズを判定するルールはないため、これはサンプルページのみの追加です。
- en / ja 両言語に対応しています（ko は既存カテゴリー同様 disabled）。
- `pnpm build:website` と `pnpm lint-fix` は通過済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)