### PR TITLE
キーボード操作の表示をPopover APIでトップレイヤーに表示

### DIFF
--- a/.changeset/keystrokes-popover.md
+++ b/.changeset/keystrokes-popover.md
@@ -1,0 +1,5 @@
+---
+"@a11y-visualizer/browser-extension": patch
+---
+
+Show the keystroke display in the top layer using the Popover API, so it appears above `<dialog>` elements and popovers, the same way the live region display does.

--- a/apps/browser_extension/entrypoints/content/components/Announcements.tsx
+++ b/apps/browser_extension/entrypoints/content/components/Announcements.tsx
@@ -17,10 +17,16 @@ export const Announcements = ({
   } = React.useContext(SettingsContext);
   const listRef = React.useRef<HTMLUListElement>(null);
   React.useEffect(() => {
-    if (listRef.current) {
-      announcements.length > 0
-        ? listRef.current.showPopover()
-        : listRef.current.hidePopover();
+    const list = listRef.current;
+    if (!list) {
+      return;
+    }
+    if (announcements.length > 0) {
+      if (!list.matches(":popover-open")) {
+        list.showPopover();
+      }
+    } else if (list.matches(":popover-open")) {
+      list.hidePopover();
     }
   }, [announcements.length]);
 

--- a/apps/browser_extension/entrypoints/content/components/Keystrokes.css
+++ b/apps/browser_extension/entrypoints/content/components/Keystrokes.css
@@ -1,7 +1,6 @@
 .KeystrokesList {
   position: fixed;
-  top: 8px;
-  right: 8px;
+  inset: 8px 8px auto auto;
   z-index: 2147483647;
   pointer-events: none;
   display: flex;
@@ -11,6 +10,9 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  border: 0;
+  background: transparent;
+  overflow: visible;
   font-family: sans-serif;
 }
 

--- a/apps/browser_extension/entrypoints/content/components/Keystrokes.tsx
+++ b/apps/browser_extension/entrypoints/content/components/Keystrokes.tsx
@@ -13,6 +13,21 @@ export const Keystrokes = React.memo(
     opacityPercent: number;
     fontSize: number;
   }) => {
+    const listRef = React.useRef<HTMLUListElement>(null);
+    React.useEffect(() => {
+      const list = listRef.current;
+      if (!list) {
+        return;
+      }
+      if (keystrokes.length > 0) {
+        if (!list.matches(":popover-open")) {
+          list.showPopover();
+        }
+      } else if (list.matches(":popover-open")) {
+        list.hidePopover();
+      }
+    }, [keystrokes.length]);
+
     return (
       <root.div mode="closed">
         <style>{Styles}</style>
@@ -22,6 +37,8 @@ export const Keystrokes = React.memo(
             opacity: opacityPercent / 100,
             fontSize: `${fontSize}px`,
           }}
+          {...{ popover: "manual" }}
+          ref={listRef}
         >
           {keystrokes.map((item) => (
             <li className="Keystroke" key={`${item.timestamp}-${item.keys}`}>


### PR DESCRIPTION
## 概要

キーボード操作の表示（キーストローク表示）を、ライブリージョンの表示と同様に Popover API（`popover="manual"`）でトップレイヤーに表示するようにしました。これにより、`<dialog>`（モーダル含む）やページ側のpopoverが開いている状態でも、キーストロークが手前に表示されます。

## 変更内容

- **`Keystrokes.tsx`**: リストの `<ul>` に `popover="manual"` を付与し、キーストロークが1件以上あるときに `showPopover()`、0件になったら `hidePopover()` を呼ぶようにした（`Announcements` と同じパターン）
- **`Keystrokes.css`**: popoverのUAデフォルトスタイル（`inset: 0; margin: auto; border: solid; background: Canvas` など）を打ち消すスタイルを追加。見た目は従来どおり画面右上に表示される
- **`Announcements.tsx`**: 表示中のpopoverに `showPopover()` を呼ぶと `InvalidStateError` が発生する潜在バグがあったため、`:popover-open` のガードを追加（キーストローク側は表示中に件数が頻繁に増減するため必須で、同じ問題があるライブリージョン側にも適用)

## テスト

- `pnpm --filter=@a11y-visualizer/browser-extension compile` ✅
- `pnpm --filter=@a11y-visualizer/browser-extension test`（430件）✅
- `pnpm build` ✅
- `pnpm lint-fix` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)